### PR TITLE
Remove subprocess calls

### DIFF
--- a/src/huntsman/drp/calibs.py
+++ b/src/huntsman/drp/calibs.py
@@ -1,12 +1,10 @@
 from dateutil.parser import parse as parse_date
-
-import lsst.daf.persistence as dafPersist
 from huntsman.drp.meta import MetaDatabase
-from lsst.utils import getPackageDir
+from datetime import datetime
+import lsst.daf.persistence as dafPersist
+from lsst.pipe.drivers.constructCalibs import BiasTask, FlatTask
 from lsst.pipe.tasks.ingestCalibs import IngestCalibsTask
-from lsst.pipe.drivers.constructCalibs import BiasTask
-from lsst.pipe.drivers.constructCalibs import FlatTask
-IngestCalibsTask.parseAndRun()
+from lsst.utils import getPackageDir
 
 
 def constructHuntsmanBiases(data_dir,
@@ -62,10 +60,10 @@ def constructHuntsmanBiases(data_dir,
     exposures = defaultdict(dict)
     for (ccd, exptime, dateobs, imageId) in metalist:
 
-        # Reject exposures outside of date range
-        # dateobs = parse_date(dateobs)
-        # if (dateobs < date_start) or (dateobs > date_end):
-        #    continue
+        Reject exposures outside of date range
+        dateobs = parse_date(dateobs)
+        if (dateobs < date_start) or (dateobs > date_end):
+            continue
 
         # Update the list of calibs we need
         if exptime not in exposures[ccd].keys():
@@ -221,8 +219,8 @@ def constructHuntsmanFlats(data_dir,
     # TODO: alert/log message when subprocess completes
 
 
-def make_recent_calibs(date,
-                       butler_directory,
+def make_recent_calibs(butler_directory,
+                       date=datetime.today().strftime('%Y-%m-%d'),
                        min_num_exposures=10,
                        date_range=7,
                        **kwargs):
@@ -231,17 +229,15 @@ def make_recent_calibs(date,
     specified date. Then saves the calib files to specified output directory.
     Parameters
     ----------
-    date : type str
-        Date specified in form yyyy-mm-dd
     butler_directory : str
         Directory containing the LSST butler database.
+    date : type str
+        Date specified in form yyyy-mm-dd, defaults to todays date.
     min_num_exposures : int
         Minimum numver of files needed to produce a master calib.
     date_range : int
         Number of days either side of specified date to search for useable
         calib data.
-    **kwargs : type
-        Description of parameter `**kwargs`.
     """
     # create a MetaDatabase instance
     db = MetaDatabase()


### PR DESCRIPTION
PR from stuff done last week.
purpose was to remove the need to use the cmdline task interface for running lsst stuff. This can be done by using the `.parseAndRun()` method on the Task objects, which will accept a list of args that would be generated from parsing the command line arguments. 
At the moment the code is just taking the cmd string that was being passed to a subprocess and splitting it by spaces and passing that list to `.parseAndRun()`. 