### PR TITLE
Coadds

### DIFF
--- a/src/huntsman/drp/butler.py
+++ b/src/huntsman/drp/butler.py
@@ -181,11 +181,12 @@ class ButlerRepository(HuntsmanBase):
 
         return self.get_metadata(dataset_type, keys=keys, data_id=data_id)
 
-    def get_calexp_data_ids(self, rerun="default", filter_name=None):
+    def get_calexp_data_ids(self, rerun="default", filter_name=None, **kwargs):
         """ Convenience function to get data_ids for calexps.
         Args:
             rerun (str, optional): The rerun name. Default: "default".
-            filter_name (str, optional): If given, only return dataIds for this filter.
+            filter_name (str, optional): If given, only return data Ids for this filter.
+            **kwargs: Parsed to self.get_data_ids.
         Returns:
             list of dict: The list of dataIds.
         """
@@ -193,7 +194,7 @@ class ButlerRepository(HuntsmanBase):
         if filter_name is not None:
             data_id["filter"] = filter_name
 
-        return self.get_data_ids("calexp", data_id=data_id, rerun=rerun)
+        return self.get_data_ids("calexp", data_id=data_id, rerun=rerun, **kwargs)
 
     def get_calexps(self, rerun="default", **kwargs):
         """ Convenience function to get the calexps produced in a given rerun.

--- a/src/huntsman/drp/butler.py
+++ b/src/huntsman/drp/butler.py
@@ -393,7 +393,7 @@ class ButlerRepository(HuntsmanBase):
 
                 # Insert the metadata into the calib database
                 metadata["filename"] = archived_filename
-                metadata["dataset_type"] = calib_type
+                metadata["datasetType"] = calib_type
                 calib_datatable.insert_one(metadata, overwrite=True)
 
     # Private methods

--- a/src/huntsman/drp/butler.py
+++ b/src/huntsman/drp/butler.py
@@ -14,7 +14,7 @@ from huntsman.drp.refcat import TapReferenceCatalogue
 from huntsman.drp.utils.date import date_to_ymd, current_date_ymd
 import huntsman.drp.lsst.utils.butler as utils
 from huntsman.drp.fitsutil import read_fits_header
-from huntsman.drp.lsst.utils.coadd import get_skymap_patch_indices
+from huntsman.drp.lsst.utils.coadd import get_patch_ids
 
 
 class ButlerRepository(HuntsmanBase):
@@ -75,10 +75,6 @@ class ButlerRepository(HuntsmanBase):
         Returns:
             butler: The butler object.
         """
-        # Rerun
-        with suppress(AttributeError):
-            rerun = rerun.split(":")[1]
-
         try:
             return self._butlers[rerun]
         except KeyError:
@@ -91,89 +87,131 @@ class ButlerRepository(HuntsmanBase):
             self._butlers[rerun] = dafPersist.Butler(inputs=butler_dir)
         return self._butlers[rerun]
 
-    def get(self, datasetType, dataId=None, rerun=None, **kwargs):
+    def get(self, dataset_type, data_id=None, rerun=None, **kwargs):
         """ Get a dataset from the butler repository.
         Args:
-            datasetType (str): The dataset type (raw, flat, bias etc.).
-            dataId (dict): The data ID that uniquely specifies a file.
+            dataset_type (str): The dataset type (raw, flat, bias etc.).
+            data_id (dict): The data ID that uniquely specifies a file.
             rerun (str, optional): The rerun name. If None (default), will use the root butler
                 directory.
         Returns:
             object: The dataset.
         """
         butler = self.get_butler(rerun=rerun)
-        return butler.get(datasetType, dataId=dataId, **kwargs)
+        return butler.get(dataset_type, dataId=data_id, **kwargs)
 
-    def get_keys(self, datasetType, **kwargs):
+    def get_keys(self, dataset_type, **kwargs):
         """ Get set of keys required to uniquely identify ingested data.
         Args:
-            datasetType (str): The dataset type (raw, flat, bias etc.).
+            dataset_type (str): The dataset type (raw, flat, bias etc.).
         Returns:
             list of str: A list of keys.
         """
         butler = self.get_butler(**kwargs)
-        return list(butler.getKeys(datasetType))
+        return list(butler.getKeys(dataset_type))
 
-    def get_filename(self, datasetType, dataId, **kwargs):
+    def get_filename(self, dataset_type, data_id, **kwargs):
         """ Get the filename for a data ID of data type.
         Args:
-            datasetType (str): The dataset type (raw, flat, bias etc.).
-            dataId (dict): The data ID that uniquely specifies a file.
+            dataset_type (str): The dataset type (raw, flat, bias etc.).
+            data_id (dict): The data ID that uniquely specifies a file.
         Returns:
             str: The filename.
         """
-        return self.get(datasetType + "_filename", dataId=dataId, **kwargs)
+        return self.get(dataset_type + "_filename", data_id=data_id, **kwargs)
 
-    def get_metadata(self, datasetType, keys, dataId=None, **kwargs):
-        """
+    def get_metadata(self, dataset_type, keys, data_id=None, **kwargs):
+        """ Get metadata for a dataset.
+        Args:
+            dataset_type (str): The dataset type (e.g. raw, flat, calexp).
+            keys (list of str): The keys contained in the metadata.
+            data_id (optional)
         """
         butler = self.get_butler(**kwargs)
-        md = butler.queryMetadata(datasetType, format=keys, dataId=dataId)
+        md = butler.queryMetadata(dataset_type, format=keys, dataId=data_id)
+
+        if len(keys) == 1:  # Butler doesn't return a consistent data structure if len(keys)=1
+            return [{keys[0]: _} for _ in md]
+
         return [{k: v for k, v in zip(keys, _)} for _ in md]
 
-    def get_data_ids(self, datasetType, dataId=None, extra_keys=None, **kwargs):
-        """ Get ingested dataIds for a given datasetType.
+    def get_calib_metadata(self, dataset_type, keys_ignore=None):
+        """ Query the ingested calibs. TODO: Replace with the "official" Butler version.
         Args:
-            datasetType (str): The datasetType (raw, bias, flat etc.).
-            dataId (dict, optional): A complete or partial dataId to match with.
-            extra_keys (list, optional): List of additional keys to be included in the dataIds.
+            dataset_type (str): The dataset type (e.g. bias, dark, flat).
+            keys_ignore (list of str, optional): If provided, drop these keys from result.
         Returns:
-            list of dict: A list of dataIds.
+            list of dict: The query result in column: value.
+        """
+        # Access the sqlite DB
+        conn = sqlite3.connect(os.path.join(self.calib_dir, "calibRegistry.sqlite3"))
+        c = conn.cursor()
+
+        # Query the calibs
+        result = c.execute(f"SELECT * from {dataset_type}")
+        metadata_list = []
+
+        for row in result:
+            d = {}
+            for idx, col in enumerate(c.description):
+                d[col[0]] = row[idx]
+            metadata_list.append(d)
+        c.close()
+
+        if keys_ignore is not None:
+            keys_keep = [k for k in metadata_list[0].keys() if k not in keys_ignore]
+            metadata_list = [{k: _[k] for k in keys_keep} for _ in metadata_list]
+
+        return metadata_list
+
+    def get_data_ids(self, dataset_type, data_id=None, extra_keys=None, **kwargs):
+        """ Get ingested data_ids for a given dataset_type.
+        Args:
+            dataset_type (str): The dataset_type (raw, bias, flat etc.).
+            data_id (dict, optional): A complete or partial data_id to match with.
+            extra_keys (list, optional): List of additional keys to be included in the data_ids.
+        Returns:
+            list of dict: A list of data_ids.
         """
         butler = self.get_butler(**kwargs)
 
-        keys = list(butler.getKeys(datasetType).keys())
+        keys = list(butler.getKeys(dataset_type).keys())
         if extra_keys is not None:
             keys.extend(extra_keys)
 
-        return self.get_metadata(datasetType, keys=keys, dataId=dataId)
+        return self.get_metadata(dataset_type, keys=keys, data_id=data_id)
 
     def get_calexp_data_ids(self, rerun="default", filter_name=None):
-        """ Convenience function to get dataIds for calexps.
-
+        """ Convenience function to get data_ids for calexps.
+        Args:
+            rerun (str, optional): The rerun name. Default: "default".
+            filter_name (str, optional): If given, only return dataIds for this filter.
+        Returns:
+            list of dict: The list of dataIds.
         """
         data_id = {"dataType": "science"}
         if filter_name is not None:
             data_id["filter"] = filter_name
 
-        return self.get_data_ids("calexp", dataId=data_id, rerun=rerun)
+        return self.get_data_ids("calexp", data_id=data_id, rerun=rerun)
 
-    def get_calexps(self, rerun="default", dataType="science", **kwargs):
+    def get_calexps(self, rerun="default", **kwargs):
         """ Convenience function to get the calexps produced in a given rerun.
         Args:
-
+            rerun (str, optional): The rerun name. Default: "default".
+            **kwargs: Parsed to self.get_calexp_data_ids.
         Returns:
             list of lsst.afw.image.exposure: The list of calexp objects.
         """
         data_ids = self.get_calexp_data_ids(rerun=rerun, **kwargs)
 
-        calexps = [self.get("calexp", dataId=d, rerun=rerun) for d in data_ids]
+        calexps = [self.get("calexp", data_id=d, rerun=rerun) for d in data_ids]
         if len(calexps) != len(data_ids):
-            raise RuntimeError("Number of dataIds does not match the number of calexps.")
+            raise RuntimeError("Number of data_ids does not match the number of calexps.")
 
         return calexps, data_ids
 
-    # Tasks
+    # Ingesting
 
     def ingest_raw_data(self, filenames, **kwargs):
         """ Ingest raw data into the repository.
@@ -182,6 +220,30 @@ class ButlerRepository(HuntsmanBase):
         """
         self.logger.debug(f"Ingesting {len(filenames)} files.")
         tasks.ingest_raw_data(filenames, butler_dir=self.butler_dir, **kwargs)
+
+    def ingest_reference_catalogue(self, filenames):
+        """ Ingest the reference catalogue into the repository.
+        Args:
+            filenames (iterable of str): The list of filenames containing reference data.
+        """
+        self.logger.debug(f"Ingesting reference catalogue from {len(filenames)} files.")
+        tasks.ingest_reference_catalogue(self.butler_dir, filenames)
+
+    def ingest_master_calibs(self, calib_type, filenames, validity=None):
+        """ Ingest the master calibs into the butler repository.
+        Args:
+            calib_type (str): The calib dataset type (e.g. bias, flat).
+            filenames (list of str): The files to ingest.
+            validity (int, optional): How many days the calibs remain valid for. Default 1000.
+        """
+        if validity is None:
+            validity = self._calib_validity
+        self.logger.info(f"Ingesting {len(filenames)} master {calib_type} calibs with validity="
+                         f"{validity}.")
+        tasks.ingest_master_calibs(calib_type, filenames, self.butler_dir,
+                                   self.calib_dir, validity=validity)
+
+    # Making
 
     def make_master_calibs(self, calib_date=None, rerun="default", skip_bias=False,
                            skip_dark=False, **kwargs):
@@ -205,72 +267,7 @@ class ButlerRepository(HuntsmanBase):
                 continue
             self.logger.info(f"Creating master {calib_type} frames for calib_date={calib_date}.")
             self._make_master_calibs(calib_type, calib_date=calib_date, rerun=rerun, **kwargs)
-            self._check_master_calibs(calib_type)
-
-    def ingest_master_calibs(self, calib_type, filenames, validity=None):
-        """ Ingest the master calibs into the butler repository.
-        Args:
-            calib_type (str): The calib dataset type (e.g. bias, flat).
-            filenames (list of str): The files to ingest.
-            validity (int, optional): How many days the calibs remain valid for. Default 1000.
-        """
-        if validity is None:
-            validity = self._calib_validity
-        self.logger.info(f"Ingesting {len(filenames)} master {calib_type} calibs with validity="
-                         f"{validity}.")
-        tasks.ingest_master_calibs(calib_type, filenames, self.butler_dir,
-                                   self.calib_dir, validity=validity)
-
-    def archive_master_calibs(self):
-        """ Copy the master calibs from this Butler repository into the calib archive directory
-        and insert the metadata into the master calib metadatabase.
-        """
-        archive_dir = self.config["directories"]["archive"]
-        calib_datatable = MasterCalibTable(config=self.config, logger=self.logger)
-
-        for calib_type in self.config["calibs"]["types"]:
-            # Retrieve filenames and dataIds for all files of this type
-            data_ids, filenames = utils.get_files_of_type(f"calibrations.{calib_type}",
-                                                          directory=self.calib_dir,
-                                                          policy=self._policy)
-            for metadata, filename in zip(data_ids, filenames):
-                # Create the filename for the archived copy
-                archived_filename = os.path.join(archive_dir,
-                                                 os.path.relpath(filename, self.calib_dir))
-                # Copy the file into the calib archive
-                self.logger.debug(f"Copying {filename} to {archived_filename}.")
-                os.makedirs(os.path.dirname(archived_filename), exist_ok=True)
-                shutil.copy(filename, archived_filename)
-
-                # Insert the metadata into the calib database
-                metadata["filename"] = archived_filename
-                metadata["datasetType"] = calib_type
-                calib_datatable.insert_one(metadata, overwrite=True)
-
-    def query_calib_metadata(self, datasetType, keys_ignore=None):
-        """ Query the ingested calibs. TODO: Replace with the "official" Butler version.
-        Args:
-            datasetType (str): The dataset type (e.g. bias, dark, flat).
-            keys_ignore (list of str, optional): If provided, drop these keys from result.
-        Returns:
-            list of dict: The query result in column: value.
-        """
-        # Access the sqlite DB
-        conn = sqlite3.connect(os.path.join(self.calib_dir, "calibRegistry.sqlite3"))
-        c = conn.cursor()
-        # Query the calibs
-        result = c.execute(f"SELECT * from {datasetType}")
-        metadata_list = []
-        for row in result:
-            d = {}
-            for idx, col in enumerate(c.description):
-                d[col[0]] = row[idx]
-            metadata_list.append(d)
-        c.close()
-        if keys_ignore is not None:
-            keys_keep = [k for k in metadata_list[0].keys() if k not in keys_ignore]
-            metadata_list = [{k: _[k] for k in keys_keep} for _ in metadata_list]
-        return metadata_list
+            self._verify_master_calibs(calib_type)
 
     def make_reference_catalogue(self, ingest=True, **kwargs):
         """ Make the reference catalogue for the ingested science frames.
@@ -286,11 +283,14 @@ class ButlerRepository(HuntsmanBase):
         ra_list = []
         dec_list = []
         for data_id, filename in zip(data_ids, filenames):
+
             data_type = butler.queryMetadata("raw", ["dataType"], dataId=data_id)[0]
+
             if data_type == "science":  # Only select science files
                 header = read_fits_header(filename, ext="all")  # Use all as .fz extension is lost
                 ra_list.append(header[self._ra_key])
                 dec_list.append(header[self._dec_key])
+
         self.logger.debug(f"Creating reference catalogue for {len(ra_list)} science frames.")
 
         # Make the reference catalogue
@@ -301,25 +301,17 @@ class ButlerRepository(HuntsmanBase):
         if ingest:
             self.ingest_reference_catalogue(filenames=(self._refcat_filename,))
 
-    def ingest_reference_catalogue(self, filenames):
-        """ Ingest the reference catalogue into the repository.
-        Args:
-            filenames (iterable of str): The list of filenames containing reference data.
-        """
-        self.logger.debug(f"Ingesting reference catalogue from {len(filenames)} files.")
-        tasks.ingest_reference_catalogue(self.butler_dir, filenames)
-
     def make_calexps(self, rerun="default", **kwargs):
         """ Make calibrated exposures (calexps) using the LSST stack.
         Args:
             rerun (str, optional): The name of the rerun. Default is "default".
             procs (int, optional): Run on this many processes (default 1).
         """
-        # Get dataIds for the raw science frames
-        data_ids = self.get_data_ids(datasetType="raw", dataId={'dataType': "science"},
+        # Get data_ids for the raw science frames
+        data_ids = self.get_data_ids(dataset_type="raw", data_id={'dataType': "science"},
                                      extra_keys=["filter"])
 
-        self.logger.info(f"Making calexps from {len(data_ids)} dataIds.")
+        self.logger.info(f"Making calexps from {len(data_ids)} data_ids.")
 
         # Process the science frames
         tasks.make_calexps(data_ids, rerun=rerun, butler_dir=self.butler_dir,
@@ -327,9 +319,9 @@ class ButlerRepository(HuntsmanBase):
 
         # Check if we have the right number of calexps
         if not len(self.get_calexps(rerun=rerun)[0]) == len(data_ids):
-            raise RuntimeError("Number of calexps does not match the number of dataIds.")
+            raise RuntimeError("Number of calexps does not match the number of data_ids.")
 
-    def make_coadds(self, filter_names=None, rerun="default:coadd", **kwargs):
+    def make_coadd(self, filter_names=None, rerun="default:coadd", **kwargs):
         """ Make a coadd from all the calexps in this repository.
         See: https://pipelines.lsst.io/getting-started/coaddition.html
         Args:
@@ -338,41 +330,69 @@ class ButlerRepository(HuntsmanBase):
             rerun (str, optional): The rerun name. Default is "default:coadd".
         """
         # Make the skymap in a chained rerun
-        self.logger.info("Creating skymap.")
+        self.logger.info("Creating sky map for coadd.")
         tasks.make_discrete_sky_map(self.butler_dir, calib_dir=self.calib_dir, rerun=rerun)
 
         # Get the output rerun
         rerun_out = rerun.split(":")[-1]
 
         # Get the tract / patch indices from the skymap
-        skymap = self.get("deepCoadd_skyMap", rerun=rerun_out)
-        patch_indices = get_skymap_patch_indices(skymap)
+        skymap_ids = self._get_skymap_ids(rerun=rerun_out)
 
         # Process all filters if filter_names is not provided
         if filter_names is None:
-            md = self.get_metadata("calexp", keys=["filter"], dataId={"dataType": "science"})
+            md = self.get_metadata("calexp", keys=["filter"], data_id={"dataType": "science"})
             filter_names = list(set([_["filter"] for _ in md]))
 
-        for filter_name in filter_names:  # TODO: Use multiprocessing here
+        self.logger.info(f"Creating coadd in {len(filter_names)} filter(s).")
 
-            # Get the calexp data ids for this band
-            data_ids = self.get_calexp_data_ids(filter_name=filter_name, rerun=rerun_out)
+        for filter_name in filter_names:
+            for tract_id, patch_ids in skymap_ids.items():  # TODO: Use multiprocessing
 
-            for tract_id, patch_idxs in patch_indices.items():  # TODO: Use multiprocessing here
+                self.logger.debug(f"Warping calexps for tract {tract_id} in {filter_name} filter.")
+
+                task_kwargs = dict(self.butler_dir, calib_dir=self.calib_dir,
+                                   rerun=rerun_out, tract_id=tract_id,
+                                   patch_ids=patch_ids, filter_name=filter_name)
 
                 # Warp the calexps onto skymap
-                tasks.make_coadd_temp_exp(self.butler_dir, calib_dir=self.calib_dir,
-                                          rerun=rerun_out, tract_id=tract_id,
-                                          patch_indices=patch_idxs, filter_name=filter_name,
-                                          data_ids=data_ids)
+                tasks.make_coadd_temp_exp(**task_kwargs)
 
                 # Combine the warped calexps
-                tasks.assemble_coadd(self.butler_dir, calib_dir=self.calib_dir, rerun=rerun_out,
-                                     tract_id=tract_id, patch_indices=patch_idxs,
-                                     filter_name=filter_name, data_ids=data_ids)
+                tasks.assemble_coadd(**task_kwargs)
 
-        # TODO: Check coadds actually exist
-        return
+        # Check all tracts and patches exist in each filter
+        self._verify_coadd(rerun_out)
+
+        self.logger.info("Successfully created coadd.")
+
+    # Archiving
+
+    def archive_master_calibs(self):
+        """ Copy the master calibs from this Butler repository into the calib archive directory
+        and insert the metadata into the master calib metadatabase.
+        """
+        archive_dir = self.config["directories"]["archive"]
+        calib_datatable = MasterCalibTable(config=self.config, logger=self.logger)
+
+        for calib_type in self.config["calibs"]["types"]:
+            # Retrieve filenames and data_ids for all files of this type
+            data_ids, filenames = utils.get_files_of_type(f"calibrations.{calib_type}",
+                                                          directory=self.calib_dir,
+                                                          policy=self._policy)
+            for metadata, filename in zip(data_ids, filenames):
+                # Create the filename for the archived copy
+                archived_filename = os.path.join(archive_dir,
+                                                 os.path.relpath(filename, self.calib_dir))
+                # Copy the file into the calib archive
+                self.logger.debug(f"Copying {filename} to {archived_filename}.")
+                os.makedirs(os.path.dirname(archived_filename), exist_ok=True)
+                shutil.copy(filename, archived_filename)
+
+                # Insert the metadata into the calib database
+                metadata["filename"] = archived_filename
+                metadata["dataset_type"] = calib_type
+                calib_datatable.insert_one(metadata, overwrite=True)
 
     # Private methods
 
@@ -387,12 +407,12 @@ class ButlerRepository(HuntsmanBase):
             with open(filename_mapper, "w") as f:
                 f.write(self._mapper)
 
-    def _check_master_calibs(self, datasetType, raise_error=True):
+    def _verify_master_calibs(self, dataset_type, raise_error=True):
         """ Check that the correct number of master calibs have been created following a call
         to make_master_calibs. This function compares the set of calibIds that should be ingested
         (using ingested raw calibs) to the calibIds that actually exist and are ingested.
         Args:
-            datasetType (str): The dataset type. Should be a valid calib dataset type (e.g. bias).
+            dataset_type (str): The dataset type. Should be a valid calib dataset type (e.g. bias).
             raise_error (bool, optional): If True (default), an error will be raised if there
                 are missing calibIds. Else, a warning is generated.
         """
@@ -401,33 +421,33 @@ class ButlerRepository(HuntsmanBase):
         keys_ignore = ["id", "calibDate", "validStart", "validEnd"]
 
         extra_keys = []
-        if datasetType == "flat":
+        if dataset_type == "flat":
             extra_keys.append("filter")  # TODO: Get this info somewhere else
 
-        # Get dataIds of raw ingested calibs
-        raw_ids = self.get_data_ids(datasetType="raw", dataId={'dataType': datasetType},
+        # Get data_ids of raw ingested calibs
+        raw_ids = self.get_data_ids(dataset_type="raw", data_id={'dataType': dataset_type},
                                     extra_keys=extra_keys)
 
         # Get calibIds of master calibs that *should* be ingested
-        calib_ids_required = utils.data_id_to_calib_id(datasetType, raw_ids, butler=butler,
+        calib_ids_required = utils.data_id_to_calib_id(dataset_type, raw_ids, butler=butler,
                                                        keys_ignore=keys_ignore)
 
         # Get calibIds of ingested master calibs
-        calib_ids_ingested = self.query_calib_metadata(datasetType, keys_ignore=keys_ignore)
+        calib_ids_ingested = self.get_calib_metadata(dataset_type, keys_ignore=keys_ignore)
 
         # Check for missing master calibs
         missing_ids = utils.get_missing_data_ids(calib_ids_ingested, calib_ids_required)
 
         # Handle result
         if len(missing_ids) > 0:
-            msg = f"{len(missing_ids)} missing master {datasetType} calibs: {missing_ids}."
+            msg = f"{len(missing_ids)} missing master {dataset_type} calibs: {missing_ids}."
             if raise_error:
                 self.logger.error(msg)
                 raise FileNotFoundError(msg)
             else:
                 self.logger.warning(msg)
         else:
-            self.logger.debug(f"No missing {datasetType} calibs detected.")
+            self.logger.debug(f"No missing {dataset_type} calibs detected.")
 
     def _make_master_calibs(self, calib_type, calib_date, rerun, ingest=True, **kwargs):
         """ Use the LSST stack to create master calibs.
@@ -443,13 +463,13 @@ class ButlerRepository(HuntsmanBase):
         butler = self.get_butler()  # Use root butler
         calib_date = date_to_ymd(calib_date)
 
-        # Get dataIds for the raw calib frames
-        data_ids = self.get_data_ids("raw", dataId={'dataType': calib_type})
-        self.logger.info(f"Found {len(data_ids)} dataIds to make master {calib_type} frames with.")
+        # Get data_ids for the raw calib frames
+        data_ids = self.get_data_ids("raw", data_id={'dataType': calib_type})
+        self.logger.info(f"Found {len(data_ids)} data_ids to make master {calib_type} frames with.")
 
         # Construct the master calibs
         self.logger.debug(f"Creating master {calib_type} frames for calibDate={calib_date} with"
-                          f" dataIds: {data_ids}.")
+                          f" data_ids: {data_ids}.")
         tasks.make_master_calibs(calib_type, data_ids, butler=butler, rerun=rerun,
                                  calib_date=calib_date, butler_dir=self.butler_dir,
                                  calib_dir=self.calib_dir, **kwargs)
@@ -464,6 +484,40 @@ class ButlerRepository(HuntsmanBase):
             self.ingest_master_calibs(calib_type, filenames)
 
         return filenames
+
+    def _get_skymap_ids(self, rerun):
+        """ Get the sky map IDs, which consist of a tract ID and associated patch IDs.
+        Args:
+            rerun (str): The rerun name.
+        Returns:
+            dict: A dict of tract_id: [patch_ids].
+        """
+        skymap = self.get("deepCoadd_skyMap", rerun=rerun)
+        return get_patch_ids(skymap)
+
+    def _verify_coadd(self, rerun, filter_names):
+        """ Verify all the coadd patches exist and can be found by the Butler.
+        Args:
+            rerun (str): The rerun name.
+            filter_names (list of str): The list of filter names to check.
+        Raises:
+            Exception: An unspecified exception is raised if there is a problem with the coadd.
+        """
+        self.logger.info("Verifying coadd.")
+
+        butler = self.get_butler(rerun=rerun)
+        skymap_ids = self.skymap_ids(rerun=rerun)
+
+        for filter_name in filter_names:
+            for tract_id, patch_ids in skymap_ids.items():
+                for patch_id in patch_ids:
+
+                    data_id = {"tract": tract_id, "patch": patch_id, "filter": filter_name}
+                    try:
+                        butler.get("deepCoadd", dataId=data_id)
+                    except Exception as err:
+                        self.logger.error(f"Error encountered while verifying coadd: {err!r}")
+                        raise err
 
 
 class TemporaryButlerRepository(ButlerRepository):

--- a/src/huntsman/drp/lsst/tasks.py
+++ b/src/huntsman/drp/lsst/tasks.py
@@ -233,36 +233,36 @@ def make_discrete_sky_map(butler_dir, calib_dir, rerun):
     run_command(cmd)
 
 
-def make_coadd_temp_exp(butler_dir, calib_dir, rerun, tract_id, patch_indices, filter_name):
+def make_coadd_temp_exp(butler_dir, calib_dir, rerun, tract_id, patch_ids, filter_name):
     """ Warp exposures onto the skymap.
     Args:
         butler_dir (str): The butler directory.
         calib_dir (str): The calib directory.
         rerun (str): The rerun name.
         tract_id (int): The tract ID.
-        patch_indices (list): A list of patch indices (x, y indices).
+        patch_ids (list): A list of patch indices (x, y indices).
         filter_name (str): The filter name.
     """
     cmd = f"makeCoaddTempExp.py {butler_dir} --calib {calib_dir} --rerun {rerun}"
-    cmd += f" --selectId filter={filter}"
+    cmd += f" --selectId filter={filter_name}"
     cmd += f" --id filter={filter_name}"
     cmd += f" tract={tract_id}"
-    cmd += " patch=" + ",".join(["^".join(_) for _ in patch_indices])
+    cmd += " patch=" + "^".join(patch_ids)
     run_command(cmd)
 
 
-def assemble_coadd(butler_dir, rerun, tract_id, patch_indices, filter_name):
+def assemble_coadd(butler_dir, calib_dir, rerun, tract_id, patch_ids, filter_name):
     """ Warp exposures onto the skymap.
     Args:
         butler_dir (str): The butler directory.
         rerun (str): The rerun name.
         tract_id (int): The tract ID.
-        patch_indices (list): A list of patch indices (x, y indices).
+        patch_ids (list): A list of patch indices (x, y indices).
         filter_name (str): The filter name.
     """
-    cmd = f"assembleCoadd.py {butler_dir} --rerun {rerun}"
-    cmd += f" --selectId filter={filter}"
+    cmd = f"assembleCoadd.py {butler_dir} --calib {calib_dir} --rerun {rerun}"
+    cmd += f" --selectId filter={filter_name}"
     cmd += f" --id filter={filter_name}"
     cmd += f" tract={tract_id}"
-    cmd += " patch=" + ",".join(["^".join(_) for _ in patch_indices])
+    cmd += " patch=" + "^".join(patch_ids)
     run_command(cmd)

--- a/src/huntsman/drp/lsst/tasks.py
+++ b/src/huntsman/drp/lsst/tasks.py
@@ -191,22 +191,21 @@ def make_calexps(data_ids, rerun, butler_directory, calib_directory, no_exit=Tru
     of making calexps including sky background maps and preliminary source catalogues and metadata,
     inclding photometric zeropoints.
 
-    Parameters
-    ----------
-    data_ids : list of abc.Mapping
-        The data IDs of the science frames to process.
-    rerun : str
-        The name of the rerun.
-    butler_directory : str
-        The butler repository directory name.
-    calib_directory : str
-        The calib directory used by the butler repository.
-    no_exit : bool, optional
-        If True (default), the program will not exit if an error is raised by the stack.
-    procs : int, optional
-        The number of processes to use per node, by default 1.
-    clobber_config : bool, optional
-        Override config values, by default False.
+    Args:
+        data_ids : list of abc.Mapping
+            The data IDs of the science frames to process.
+        rerun : str
+            The name of the rerun.
+        butler_directory : str
+            The butler repository directory name.
+        calib_directory : str
+            The calib directory used by the butler repository.
+        no_exit : bool, optional
+            If True (default), the program will not exit if an error is raised by the stack.
+        procs : int, optional
+            The number of processes to use per node, by default 1.
+        clobber_config : bool, optional
+            Override config values, by default False.
     """
     cmd = f"processCcd.py {butler_directory}"
     if no_exit:
@@ -223,61 +222,45 @@ def make_calexps(data_ids, rerun, butler_directory, calib_directory, no_exit=Tru
     run_command(cmd)
 
 
-def makeDiscreteSkyMap(butler_directory='DATA', rerun='processCcdOutputs:coadd'):
+def make_discrete_sky_map(butler_directory, rerun):
     """Create a sky map that covers processed exposures.
-
-    Parameters
-    ----------
-    butler_directory : str, optional
-        The butler repository directory name, by default 'DATA'.
-    rerun : str, optional
-        The name of the rerun, by default 'processCcdOutputs:coadd'.
+    Args:
+        butler_directory (str): The butler directory.
+        rerun (str): The rerun name.
     """
-    cmd = f"makeDiscreteSkyMap.py {butler_directory} --id --rerun {rerun} "
-    cmd += "--config skyMap.projection='TAN'"
-    subprocess.check_output(cmd, shell=True)
+    cmd = f"makeDiscreteSkyMap.py {butler_directory} --id --rerun {rerun}"
+    run_command(cmd)
 
 
-def makeCoaddTempExp(filter, butler_directory='DATA', calib_directory='DATA/CALIB',
-                     rerun='coadd'):
-    """Warp exposures onto sky map.
-
-    Parameters
-    ----------
-    filter : str
-        Name of filter to use for task.
-    butler_directory : str, optional
-        The butler repository directory name, by default 'DATA'.
-    calib_directory : str, optional
-        The calib directory used by the butler repository, by default 'DATA/CALIB'.
-    rerun : str, optional
-        The name of the rerun, by default 'coadd'.
+def make_coadd_temp_exp(butler_directory, rerun, tract_id, patch_indices, filter_name):
+    """ Warp exposures onto the skymap.
+    Args:
+        butler_directory (str): The butler directory.
+        rerun (str): The rerun name.
+        tract_id (int): The tract ID.
+        patch_indices (list): A list of patch indices (x, y indices).
+        filter_name (str): The filter name.
     """
-    cmd = f"makeCoaddTempExp.py {butler_directory} --rerun {rerun} "
-    cmd += f"--selectId filter={filter} --id filter={filter} tract=0 "
-    cmd += "patch=0,0^0,1^0,2^1,0^1,1^1,2^2,0^2,1^2,2"
-    cmd += "--config doApplyUberCal=False"
-    print(f'The command is: {cmd}')
-    subprocess.check_output(cmd, shell=True)
+    cmd = f"makeCoaddTempExp.py {butler_directory} --rerun {rerun}"
+    cmd += f" --selectId filter={filter}"
+    cmd += f" --id filter={filter_name}"
+    cmd += f" tract={tract_id}"
+    cmd += " patch=" + ",".join(["^".join(_) for _ in patch_indices])
+    run_command(cmd)
 
 
-def assembleCoadd(filter, butler_directory='DATA', calib_directory='DATA/CALIB',
-                  rerun='coadd'):
-    """Assemble the warped exposures into a coadd.
-
-    Parameters
-    ----------
-    filter : str
-        Name of filter to use for task.
-    butler_directory : str, optional
-        The butler repository directory name, by default 'DATA'.
-    calib_directory : str, optional
-        The calib directory used by the butler repository, by default 'DATA/CALIB'.
-    rerun : str, optional
-        The name of the rerun, by default 'coadd'.
+def assemble_coadd(butler_directory, rerun, tract_id, patch_indices, filter_name):
+    """ Warp exposures onto the skymap.
+    Args:
+        butler_directory (str): The butler directory.
+        rerun (str): The rerun name.
+        tract_id (int): The tract ID.
+        patch_indices (list): A list of patch indices (x, y indices).
+        filter_name (str): The filter name.
     """
-    cmd = f"assembleCoadd.py {butler_directory} --rerun {rerun} "
-    cmd += f"--selectId filter={filter} --id filter={filter} tract=0 "
-    cmd += "patch=0,0^0,1^0,2^1,0^1,1^1,2^2,0^2,1^2,2"
-    print(f'The command is: {cmd}')
-    subprocess.check_output(cmd, shell=True)
+    cmd = f"assembleCoadd.py {butler_directory} --rerun {rerun}"
+    cmd += f" --selectId filter={filter}"
+    cmd += f" --id filter={filter_name}"
+    cmd += f" tract={tract_id}"
+    cmd += " patch=" + ",".join(["^".join(_) for _ in patch_indices])
+    run_command(cmd)

--- a/src/huntsman/drp/lsst/tasks.py
+++ b/src/huntsman/drp/lsst/tasks.py
@@ -40,7 +40,7 @@ def run_command(cmd, logger=None):
     return subprocess.run(cmd, shell=True, check=True)
 
 
-def ingest_raw_data(filenames, butler_directory, mode="link", ignore_ingested=True):
+def ingest_raw_data(filenames, butler_dir, mode="link", ignore_ingested=True):
     """ Ingest raw files into a butler repository.
     Args:
         filenames (list of str): The list of filenames to ingest.
@@ -52,18 +52,18 @@ def ingest_raw_data(filenames, butler_directory, mode="link", ignore_ingested=Tr
     """
     # Create the ingest task
     task = IngestTask()
-    task = task.prepareTask(root=butler_directory, mode=mode, ignoreIngested=ignore_ingested)
+    task = task.prepareTask(root=butler_dir, mode=mode, ignoreIngested=ignore_ingested)
 
     # Ingest the files
     task.ingestFiles(filenames)
 
 
-def ingest_reference_catalogue(butler_directory, filenames, output_directory=None):
+def ingest_reference_catalogue(butler_dir, filenames, output_directory=None):
     """Ingest a photometric reference catalogue (currently skymapper).
 
     Parameters
     ----------
-    butler_directory : str
+    butler_dir : str
         Directory that contains the butler repo.
     filenames : list
         List of reference catalogue files to ingest.
@@ -71,7 +71,7 @@ def ingest_reference_catalogue(butler_directory, filenames, output_directory=Non
         Directory that contains the output data reposity, by default None.
     """
     if output_directory is None:
-        output_directory = butler_directory
+        output_directory = butler_dir
 
     # Load the config file
     pkgdir = getPackageDir("obs_huntsman")
@@ -80,7 +80,7 @@ def ingest_reference_catalogue(butler_directory, filenames, output_directory=Non
     config.load(config_file)
 
     # Convert the files into the correct format and place them into the repository
-    args = [butler_directory,
+    args = [butler_dir,
             "--configfile", config_file,
             "--output", output_directory,
             "--clobber-config",
@@ -88,7 +88,7 @@ def ingest_reference_catalogue(butler_directory, filenames, output_directory=Non
     HuntsmanIngestIndexedReferenceTask.parseAndRun(args=args)
 
 
-def ingest_master_calibs(datasetType, filenames, butler_directory, calib_directory, validity):
+def ingest_master_calibs(datasetType, filenames, butler_dir, calib_dir, validity):
     """Ingest the master calib of a given date.
 
     Parameters
@@ -97,18 +97,18 @@ def ingest_master_calibs(datasetType, filenames, butler_directory, calib_directo
         Can be set to "bias" or "flat".
     filenames : list
         List of reference catalogue files to ingest.
-    butler_directory : str
+    butler_dir : str
         Directory that contains the butler repo.
-    calib_directory : str
+    calib_dir : str
         Directory that contains the calib repo.
     validity : int
         validity period in days for calib files.
 
     """
-    cmd = f"ingestCalibs.py {butler_directory}"
+    cmd = f"ingestCalibs.py {butler_dir}"
     cmd += " " + " ".join(filenames)
     cmd += f" --validity {validity}"
-    cmd += f" --calib {calib_directory} --mode=link"
+    cmd += f" --calib {calib_dir} --mode=link"
 
     # We currently have to provide the config explicitly
     config_file = INGEST_CALIB_CONFIGS[datasetType]
@@ -121,7 +121,7 @@ def ingest_master_calibs(datasetType, filenames, butler_directory, calib_directo
     run_command(cmd)
 
 
-def make_master_calibs(datasetType, data_ids, calib_date, butler, butler_directory, calib_directory,
+def make_master_calibs(datasetType, data_ids, calib_date, butler, butler_dir, calib_dir,
                        rerun, nodes=1, procs=1):
     """Use constructBias.py to construct master bias frames for the data_ids. The master calibs are
     produced for each unique calibId obtainable from the list of dataIds.
@@ -137,9 +137,9 @@ def make_master_calibs(datasetType, data_ids, calib_date, butler, butler_directo
         by huntsman.drp.utils.date.date_parser.
     butler : huntsman.drp.butler.ButlerRepository
         The butler repository object.
-    butler_directory : str
+    butler_dir : str
         Directory that contains the butler repo.
-    calib_directory : str
+    calib_dir : str
         Directory that contains the calib repo.
     rerun : str
         The name of the rerun to use.
@@ -171,8 +171,8 @@ def make_master_calibs(datasetType, data_ids, calib_date, butler, butler_directo
         data_id_subset = [d for d in data_ids if calib_id.items() <= d.items()]
 
         # Construct the command
-        cmd = f"{script_name} {butler_directory} --rerun {rerun}"
-        cmd += f" --calib {calib_directory}"
+        cmd = f"{script_name} {butler_dir} --rerun {rerun}"
+        cmd += f" --calib {calib_dir}"
         for data_id in data_id_subset:
             cmd += " --id"
             for k, v in data_id.items():
@@ -184,7 +184,7 @@ def make_master_calibs(datasetType, data_ids, calib_date, butler, butler_directo
         run_command(cmd)
 
 
-def make_calexps(data_ids, rerun, butler_directory, calib_directory, no_exit=True, procs=1,
+def make_calexps(data_ids, rerun, butler_dir, calib_dir, no_exit=True, procs=1,
                  clobber_config=False):
     """ Make calibrated exposures (calexps) using the LSST stack. These are astrometrically
     and photometrically calibrated as well as background subtracted. There are several byproducts
@@ -196,9 +196,9 @@ def make_calexps(data_ids, rerun, butler_directory, calib_directory, no_exit=Tru
             The data IDs of the science frames to process.
         rerun : str
             The name of the rerun.
-        butler_directory : str
+        butler_dir : str
             The butler repository directory name.
-        calib_directory : str
+        calib_dir : str
             The calib directory used by the butler repository.
         no_exit : bool, optional
             If True (default), the program will not exit if an error is raised by the stack.
@@ -207,11 +207,11 @@ def make_calexps(data_ids, rerun, butler_directory, calib_directory, no_exit=Tru
         clobber_config : bool, optional
             Override config values, by default False.
     """
-    cmd = f"processCcd.py {butler_directory}"
+    cmd = f"processCcd.py {butler_dir}"
     if no_exit:
         cmd += " --noExit"
     cmd += f" --rerun {rerun}"
-    cmd += f" --calib {calib_directory}"
+    cmd += f" --calib {calib_dir}"
     cmd += f" -j {procs}"
     for data_id in data_ids:
         cmd += " --id"
@@ -222,26 +222,28 @@ def make_calexps(data_ids, rerun, butler_directory, calib_directory, no_exit=Tru
     run_command(cmd)
 
 
-def make_discrete_sky_map(butler_directory, rerun):
+def make_discrete_sky_map(butler_dir, calib_dir, rerun):
     """Create a sky map that covers processed exposures.
     Args:
-        butler_directory (str): The butler directory.
+        butler_dir (str): The butler directory.
+        calib_dir (str): The calib directory.
         rerun (str): The rerun name.
     """
-    cmd = f"makeDiscreteSkyMap.py {butler_directory} --id --rerun {rerun}"
+    cmd = f"makeDiscreteSkyMap.py {butler_dir} --calib {calib_dir} --id --rerun {rerun}"
     run_command(cmd)
 
 
-def make_coadd_temp_exp(butler_directory, rerun, tract_id, patch_indices, filter_name):
+def make_coadd_temp_exp(butler_dir, calib_dir, rerun, tract_id, patch_indices, filter_name):
     """ Warp exposures onto the skymap.
     Args:
-        butler_directory (str): The butler directory.
+        butler_dir (str): The butler directory.
+        calib_dir (str): The calib directory.
         rerun (str): The rerun name.
         tract_id (int): The tract ID.
         patch_indices (list): A list of patch indices (x, y indices).
         filter_name (str): The filter name.
     """
-    cmd = f"makeCoaddTempExp.py {butler_directory} --rerun {rerun}"
+    cmd = f"makeCoaddTempExp.py {butler_dir} --calib {calib_dir} --rerun {rerun}"
     cmd += f" --selectId filter={filter}"
     cmd += f" --id filter={filter_name}"
     cmd += f" tract={tract_id}"
@@ -249,16 +251,16 @@ def make_coadd_temp_exp(butler_directory, rerun, tract_id, patch_indices, filter
     run_command(cmd)
 
 
-def assemble_coadd(butler_directory, rerun, tract_id, patch_indices, filter_name):
+def assemble_coadd(butler_dir, rerun, tract_id, patch_indices, filter_name):
     """ Warp exposures onto the skymap.
     Args:
-        butler_directory (str): The butler directory.
+        butler_dir (str): The butler directory.
         rerun (str): The rerun name.
         tract_id (int): The tract ID.
         patch_indices (list): A list of patch indices (x, y indices).
         filter_name (str): The filter name.
     """
-    cmd = f"assembleCoadd.py {butler_directory} --rerun {rerun}"
+    cmd = f"assembleCoadd.py {butler_dir} --rerun {rerun}"
     cmd += f" --selectId filter={filter}"
     cmd += f" --id filter={filter_name}"
     cmd += f" tract={tract_id}"

--- a/src/huntsman/drp/lsst/tasks.py
+++ b/src/huntsman/drp/lsst/tasks.py
@@ -252,7 +252,7 @@ def make_coadd_temp_exp(butler_dir, calib_dir, rerun, tract_id, patch_ids, filte
 
 
 def assemble_coadd(butler_dir, calib_dir, rerun, tract_id, patch_ids, filter_name):
-    """ Warp exposures onto the skymap.
+    """ Assemble the coadd from warped exposures.
     Args:
         butler_dir (str): The butler directory.
         rerun (str): The rerun name.

--- a/src/huntsman/drp/lsst/utils/butler.py
+++ b/src/huntsman/drp/lsst/utils/butler.py
@@ -138,22 +138,3 @@ def data_id_to_calib_id(datasetType, data_ids, butler, keys_ignore=None):
         calib_keys = [k for k in calib_keys if k not in keys_ignore]
     calib_ids = [{k: data_id[k] for k in calib_keys} for data_id in data_ids]
     return calib_ids
-
-
-def get_data_ids(butler, datasetType, dataId=None, extra_keys=None):
-    """ Get dataIds for datasetType.
-    Args:
-        butler (butler): The butler object.
-        datasetType (str): The datasetType (raw, bias, flat etc.).
-        dataId (dict, optional): A complete or partial dataId to match with.
-        extra_keys (list, optional): List of additional keys to be included in the dataIds.
-    Returns:
-        list of dict: A list of dataIds.
-    """
-    keys = list(butler.getKeys(datasetType).keys())
-    if extra_keys is not None:
-        keys.extend(extra_keys)
-
-    value_list = butler.queryMetadata(datasetType, format=keys, dataId=dataId)
-
-    return [{k: v for k, v in zip(keys, _)} for _ in value_list]

--- a/src/huntsman/drp/lsst/utils/coadd.py
+++ b/src/huntsman/drp/lsst/utils/coadd.py
@@ -4,7 +4,7 @@ See: https://github.com/lsst/pipe_tasks/blob/master/python/lsst/pipe/tasks/makeD
 from collections import defaultdict
 
 
-def get_skymap_patch_indices(skymap):
+def get_patch_ids(skymap):
     """
     """
     indices = defaultdict(list)
@@ -18,6 +18,6 @@ def get_skymap_patch_indices(skymap):
         ny = tract_info.getNumPatches()[1]
         for x in range(nx):
             for y in range(ny):
-                indices[tract_id].append((x, y))
+                indices[tract_id].append(f"{x},{y}")
 
     return indices

--- a/src/huntsman/drp/lsst/utils/coadd.py
+++ b/src/huntsman/drp/lsst/utils/coadd.py
@@ -4,8 +4,13 @@ See: https://github.com/lsst/pipe_tasks/blob/master/python/lsst/pipe/tasks/makeD
 from collections import defaultdict
 
 
-def get_patch_ids(skymap):
-    """
+def get_skymap_ids(skymap):
+    """ Get the full set of skymap patch IDs from a given skymap.
+    Args:
+        skymap (lsst.skymap.discreteSkyMap.DiscreteSkyMap): The skymap object.
+    Returns:
+        dict: A dictionary of tractID: List of patch IDs. Each patch IDs is specified by two
+            indices (x and y), in this case they are returned as a single string, `x,y`.
     """
     indices = defaultdict(list)
     for tract_info in skymap:

--- a/src/huntsman/drp/lsst/utils/coadd.py
+++ b/src/huntsman/drp/lsst/utils/coadd.py
@@ -1,0 +1,23 @@
+"""
+See: https://github.com/lsst/pipe_tasks/blob/master/python/lsst/pipe/tasks/makeDiscreteSkyMap.py
+"""
+from collections import defaultdict
+
+
+def get_skymap_patch_indices(skymap):
+    """
+    """
+    indices = defaultdict(list)
+    for tract_info in skymap:
+
+        # Identify the tract
+        tract_id = tract_info.getId()
+
+        # Get lists of x-y patch indices in this tract
+        nx = tract_info.getNumPatches()[0]
+        ny = tract_info.getNumPatches()[1]
+        for x in range(nx):
+            for y in range(ny):
+                indices[tract_id].append((x, y))
+
+    return indices

--- a/src/huntsman/drp/tests/test_butler.py
+++ b/src/huntsman/drp/tests/test_butler.py
@@ -131,11 +131,16 @@ def test_make_master_calibs(exposure_table, temp_butler_repo, config):
             assert os.path.isfile(filename)
 
 
-def test_make_calexp(tmpdir):
-    """ Test that we can make calibrated exposures. """
+def test_make_coadd(tmpdir):
+    """ Test that we can make coadds. """
     br = create_test_bulter_repository(str(tmpdir))
+
     br.make_master_calibs()
+
     br.make_calexps()
+
+    br.make_coadd()  # Implicit verification
+
     calexps, data_ids = br.get_calexps()
     assert len(calexps) == 1
     assert len(data_ids) == 1

--- a/src/huntsman/drp/tests/test_butler.py
+++ b/src/huntsman/drp/tests/test_butler.py
@@ -9,7 +9,7 @@ def test_initialise(butler_repos):
     """Make sure the repos are created properly"""
     for butler_repo in butler_repos:
         with butler_repo:
-            for dir in [butler_repo.butler_directory, butler_repo.calib_directory]:
+            for dir in [butler_repo.butler_dir, butler_repo.calib_dir]:
                 assert os.path.isdir(dir)
                 assert "_mapper" in os.listdir(dir)
             assert butler_repo.get_butler() is not None
@@ -17,7 +17,7 @@ def test_initialise(butler_repos):
 
 def test_temp_repo(temp_butler_repo):
     """Test the temp butler repo behaves as expected"""
-    attrs = ["butler_directory", "calib_directory"]
+    attrs = ["butler_dir", "calib_dir"]
     for a in attrs:
         assert getattr(temp_butler_repo, a) is None
     with temp_butler_repo:
@@ -92,7 +92,7 @@ def test_make_master_calibs(exposure_table, temp_butler_repo, config):
         br.archive_master_calibs()
 
         # Check the biases in the butler dir
-        metadata_bias = br.query_calib_metadata(datasetType="bias")
+        metadata_bias = br.get_calib_metadata(dataset_type="bias")
         assert len(metadata_bias) == n_bias
         ccds = set()
         for md in metadata_bias:
@@ -100,7 +100,7 @@ def test_make_master_calibs(exposure_table, temp_butler_repo, config):
         assert len(ccds) == test_config["n_cameras"]
 
         # Check the darks in the butler dir
-        metadata_dark = br.query_calib_metadata(datasetType="dark")
+        metadata_dark = br.get_calib_metadata(dataset_type="dark")
         assert len(metadata_dark) == n_dark
         ccds = set()
         for md in metadata_dark:
@@ -108,7 +108,7 @@ def test_make_master_calibs(exposure_table, temp_butler_repo, config):
         assert len(ccds) == test_config["n_cameras"]
 
         # Check the flats in the butler dir
-        metadata_flat = br.query_calib_metadata(datasetType="flat")
+        metadata_flat = br.get_calib_metadata(dataset_type="flat")
         assert len(metadata_flat) == n_flat
         filters = set()
         ccds = set()


### PR DESCRIPTION
- Adds functionality to produce a coadd from all the calexps in a butler repository.
- `butler_directory` -> `butler_dir,` `calib_directory` -> `calib_dir` (shorter)
- `query_calib_metadata` -> `get_calib_metadata` (consistent with other similar methods)
- "CamelCase" should only be used when directly calling LSST functions, otherwise use "snake_case"

Lots of small changes but the main bulk is in `butler.py`.