### PR TITLE
Fix duplicate document problem in `CalexpQualityMonitor`

### DIFF
--- a/src/huntsman/drp/document.py
+++ b/src/huntsman/drp/document.py
@@ -60,7 +60,14 @@ class Document(abc.Mapping):
         return len(self._document)
 
     def __str__(self):
-        return str({k: self._document[k] for k in self._required_keys})
+        if self._required_keys:
+            return str({k: self._document[k] for k in self._required_keys})
+        return str(self._document)
+
+    def __repr__(self):
+        if self._required_keys:
+            return repr({k: self._document[k] for k in self._required_keys})
+        return repr(self._document)
 
     # Public methods
 


### PR DESCRIPTION
- Use the original document as the document filter when updating calexp metrics in `RawExposureCollection`
- This avoids clashes when there are duplicate `.fits` and `.fits.fz` files.
- Also fix string representation of `Document` objects.

Closes #117 
Closes #123