### PR TITLE
Use mongodb to verify new document is unique

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -59,6 +59,25 @@ mongodb:
   hostname: "localhost"
   port: 27017
   db_name: "huntsman"
+  collections:
+    RawExposureCollection:
+      name: "raw_exposures"
+      unique_keys:
+        - "filename"
+    MasterCalibCollection:
+      name: "master_calibs"
+      type_key: "datasetType"
+      unique_keys:
+        bias:
+          - "ccd"
+          - "calibDate"
+        dark:
+          - "ccd"
+          - "calibDate"
+        flat:
+          - "filter"
+          - "ccd"
+          - "calibDate"
 
 calibs:
   types:  # Order might be important...

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -66,18 +66,8 @@ mongodb:
         - "filename"
     MasterCalibCollection:
       name: "master_calibs"
-      type_key: "datasetType"
       unique_keys:
-        bias:
-          - "ccd"
-          - "calibDate"
-        dark:
-          - "ccd"
-          - "calibDate"
-        flat:
-          - "filter"
-          - "ccd"
-          - "calibDate"
+        - "filename"  # Let obs_huntsman handle unique calib file naming
 
 calibs:
   types:  # Order might be important...

--- a/src/huntsman/drp/collection.py
+++ b/src/huntsman/drp/collection.py
@@ -271,24 +271,13 @@ class Collection(HuntsmanBase):
         inserts.
         See: https://docs.mongodb.com/manual/core/index-unique
         """
-        cfg = self.config["mongodb"]["collections"].get(self.__class__.__name__)
+        cfg = self.config["mongodb"]["collections"].get(self.__class__.__name__, {})
 
-        unique_keys = cfg["unique_keys"]
+        unique_keys = cfg.get("unique_keys", None)
         if not unique_keys:
             return
 
-        # If it is a mapping, unique keys are applied separately for each data type
-        elif isinstance(unique_keys, abc.Mapping):
-            for data_type, keys in unique_keys.items():
-                data_type_key = cfg["type_key"]
-                pfe = {data_type_key: {"$eq": data_type}}
-                self._collection.create_index([(k, pymongo.ASCENDING) for k in keys], unique=True,
-                                              partialFilterExpression=pfe)
-
-        # If it is an iterable, unique keys apply to all data types
-        else:
-            self._collection.create_index([(k, pymongo.ASCENDING) for k in unique_keys],
-                                          unique=True)
+        self._collection.create_index([(k, pymongo.ASCENDING) for k in unique_keys], unique=True)
 
     def _get_quality_filter(self):
         """ Return the Query object corresponding to quality cuts. """

--- a/src/huntsman/drp/collection.py
+++ b/src/huntsman/drp/collection.py
@@ -1,6 +1,5 @@
 """Code to interface with the Huntsman mongo database."""
 from contextlib import suppress
-from collections import abc
 from datetime import timedelta
 from urllib.parse import quote_plus
 
@@ -141,7 +140,7 @@ class Collection(HuntsmanBase):
         # Insert the document
         # Uniqueness is verified implicitly
         self.logger.debug(f"Inserting document into {self}: {doc}.")
-        self._collection.insert_one(doc.to_mongo())
+        self._collection.insert_one(doc.to_mongo(flatten=False))
 
     def replace_one(self, document_filter, replacement, **kwargs):
         """ Replace a matching document with a new one.
@@ -290,10 +289,9 @@ class Collection(HuntsmanBase):
         cfg = self.config["mongodb"]["collections"].get(self.__class__.__name__, {})
 
         unique_keys = cfg.get("unique_keys", None)
-        if not unique_keys:
-            return
-
-        self._collection.create_index([(k, pymongo.ASCENDING) for k in unique_keys], unique=True)
+        if unique_keys:
+            self._collection.create_index([(k, pymongo.ASCENDING) for k in unique_keys],
+                                          unique=True)
 
     def _get_quality_filter(self):
         """ Return the Query object corresponding to quality cuts. """

--- a/src/huntsman/drp/collection.py
+++ b/src/huntsman/drp/collection.py
@@ -248,6 +248,13 @@ class Collection(HuntsmanBase):
         date_start = date_now - timedelta(days=days, hours=hours, seconds=seconds)
         return self.find(date_start=date_start, **kwargs)
 
+    def delete_all(self, really=False):
+        """ Delete all documents from the collection. """
+        if not really:
+            raise RuntimeError("If you really want to do this, parse really=True.")
+        docs = self.find()
+        self.delete_many(docs, force=True)
+
     # Private methods
 
     def _connect(self):

--- a/src/huntsman/drp/document.py
+++ b/src/huntsman/drp/document.py
@@ -7,7 +7,7 @@ from astropy import units as u
 
 from huntsman.drp.core import get_config
 from huntsman.drp.utils.date import parse_date
-from huntsman.drp.utils.mongo import encode_mongo_filter
+from huntsman.drp.utils.mongo import encode_mongo_filter, unflatten_dict
 
 
 class Document(abc.Mapping):
@@ -83,9 +83,12 @@ class Document(abc.Mapping):
     def update(self, d):
         self._document.update(d)
 
-    def to_mongo(self):
+    def to_mongo(self, flatten=True):
         """ Get the full mongo filter for the document """
-        return encode_mongo_filter(self._document)
+        d = encode_mongo_filter(self._document)
+        if not flatten:
+            return unflatten_dict(d)
+        return d
 
     def get_mongo_id(self):
         """ Get the unique mongo ID for the document """

--- a/src/huntsman/drp/lsst/butler.py
+++ b/src/huntsman/drp/lsst/butler.py
@@ -418,6 +418,7 @@ class ButlerRepository(HuntsmanBase):
     def archive_master_calibs(self):
         """ Copy the master calibs from this Butler repository into the calib archive directory
         and insert the metadata into the master calib metadatabase.
+        TODO: Move this functionality out of the ButlerRepository class.
         """
         for datasetType in self.config["calibs"]["types"]:
 
@@ -441,7 +442,9 @@ class ButlerRepository(HuntsmanBase):
                 shutil.copy(filename, archived_filename)
 
                 # Insert the metadata into the calib database
-                self._calib_collection.insert_one(metadata, overwrite=True)
+                # Use replace operation with upsert because old document may already exist
+                document_filter = {"filename": filename}
+                self._calib_collection.replace_one(document_filter, metadata, upsert=True)
 
     # Private methods
 

--- a/src/huntsman/drp/tests/conftest.py
+++ b/src/huntsman/drp/tests/conftest.py
@@ -123,13 +123,12 @@ def exposure_collection_real_data(config, fits_header_translator):
     raw data table.
     """
     # Populate the database
-    exposure_collection = testing.create_test_exposure_collection(config)
+    exposure_collection = testing.create_test_exposure_collection(config, clear=True)
 
     yield exposure_collection
 
     # Remove the metadata from the DB ready for other tests
-    all_metadata = exposure_collection.find()
-    exposure_collection.delete_many(all_metadata)
+    exposure_collection.delete_all(really=True)
 
 
 @pytest.fixture(scope="function")

--- a/src/huntsman/drp/tests/test_butler.py
+++ b/src/huntsman/drp/tests/test_butler.py
@@ -72,7 +72,7 @@ def test_ingest(exposure_collection, butler_repos, config):
 
 
 def test_make_master_calibs(exposure_collection, temp_butler_repo, config):
-    """ Make sure the correct number of master bias frames are produced."""
+    """ Make sure the correct number of master bias frames are produced. """
     test_config = config["exposure_sequence"]
     n_filters = len(test_config["filters"])
 
@@ -132,7 +132,7 @@ def test_make_master_calibs(exposure_collection, temp_butler_repo, config):
 
 
 def test_make_coadd(tmpdir):
-    """ Test that we can make coadds. """
+    """ Test that we can make coadds """
     br = create_test_bulter_repository(str(tmpdir))
 
     br.make_master_calibs(validity=1000)

--- a/src/huntsman/drp/tests/test_collection.py
+++ b/src/huntsman/drp/tests/test_collection.py
@@ -7,7 +7,7 @@ from huntsman.drp.utils.date import current_date, parse_date
 from huntsman.drp.fitsutil import read_fits_header
 from huntsman.drp.collection import RawExposureCollection
 
-from pymongo.errors import ServerSelectionTimeoutError
+from pymongo.errors import ServerSelectionTimeoutError, DuplicateKeyError
 
 
 def test_mongodb_wrong_host_name(config):
@@ -124,7 +124,7 @@ def test_insert_duplicate(exposure_collection):
 
     doc = exposure_collection.find()[0]
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(DuplicateKeyError):
         exposure_collection.insert_one(doc)
 
 
@@ -140,11 +140,11 @@ def test_ingest_duplicate_fpack(exposure_collection):
     doc2["filename"] = "test_insert_duplicate.fits.fz"
 
     exposure_collection.insert_one(doc1)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(DuplicateKeyError):
         exposure_collection.insert_one(doc2)
 
     exposure_collection.delete_many(exposure_collection.find(), force=True)
 
     exposure_collection.insert_one(doc2)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(DuplicateKeyError):
         exposure_collection.insert_one(doc1)

--- a/src/huntsman/drp/utils/mongo.py
+++ b/src/huntsman/drp/utils/mongo.py
@@ -54,6 +54,30 @@ def _flatten_dict(d, parent_key=None, sep='.'):
     return dict(items)
 
 
+def unflatten_dict(d, sep="."):
+    """ Unflatten a flattened dictionary.
+    This is useful for inserting nested, encoded documents into collections.
+    Args:
+        d (dict): The dictionary to flatten.
+        sep (str, optional): Separater character, default: '.'.
+    Returns:
+        dict: The un-flattened (nested) dictionary.
+    """
+    result = {}
+    for k, v in d.items():
+        _unflatten_dict_split(k, v, result, sep=sep)
+    return result
+
+
+def _unflatten_dict_split(k, v, out, sep):
+    """ Utility function for unflatten_dict. """
+    k, *rest = k.split(sep, 1)
+    if rest:
+        _unflatten_dict_split(rest[0], v, out.setdefault(k, {}), sep=sep)
+    else:
+        out[k] = v
+
+
 def encode_mongo_document(value):
     """ Encode object for a pymongo query.
     Args:

--- a/src/huntsman/drp/utils/testing.py
+++ b/src/huntsman/drp/utils/testing.py
@@ -85,13 +85,15 @@ def create_test_bulter_repository(directory, config=None, **kwargs):
     return br
 
 
-def create_test_exposure_collection(config, name="real_data"):
+def create_test_exposure_collection(config, name="real_data", clear=False):
     """ Ingest real testing images into a RawExposureCollection
     """
     dir = get_testdata_dir(config)
     filenames = get_testdata_fits_filenames(config)
 
     exposure_collection = RawExposureCollection(config=config, collection_name=name)
+    if clear:
+        exposure_collection.delete_all(really=True)
 
     # Make and start FileIngestor object
     ing = FileIngestor(directory=dir, config=config, exposure_collection=exposure_collection)


### PR DESCRIPTION
The current implementation is non-atomic (not thread-safe) since multiple clients can insert a duplicated document if they attempt to do so at roughly the same time. This PR fixes that problem by relying on mongodb's internal (server-side) locking mechanism.

Closes #120 
Closes #128