### PR TITLE
Specify LSST task config items in reduction file

### DIFF
--- a/config/reductions/test-lsst.yaml
+++ b/config/reductions/test-lsst.yaml
@@ -1,5 +1,6 @@
 type: huntsman.drp.reduction.lsst.LsstDataReduction
 name: example-reduction
+
 query:
   document_filter:
     dataType: science
@@ -10,3 +11,7 @@ query:
   screen: true
   quality_filter: true
   limit: 1
+
+calexp_kwargs:
+  extra_config:
+    charImage.background.algorithm: CONSTANT

--- a/src/huntsman/drp/lsst/tasks/__init__.py
+++ b/src/huntsman/drp/lsst/tasks/__init__.py
@@ -2,7 +2,6 @@
 Eventually we should stop using these and call LSST functions directly.
 """
 import os
-from contextlib import suppress
 
 from lsst.pipe.tasks.ingest import IngestTask
 from lsst.utils import getPackageDir
@@ -138,7 +137,7 @@ def make_calexp(dataId, rerun, butler_dir, calib_dir, doReturnResults=True, **kw
 
 
 def make_calexps(dataIds, rerun, butler_dir, calib_dir, procs=1, clobber_config=False,
-                 doReturnResults=False, **kwargs):
+                 doReturnResults=False, extra_config=None, **kwargs):
     """ Make calibrated exposures (calexps) using the LSST stack.
     Args:
         dataIds (list of abc.Mapping): The data IDs of the science frames to process.
@@ -148,6 +147,7 @@ def make_calexps(dataIds, rerun, butler_dir, calib_dir, procs=1, clobber_config=
         procs (int, optional): The number of processes to use per node, by default 1.
         clobber_config (bool, optional): Override config values, by default False.
         doReturnResults (bool): If True, return results from LSST task. Default: False.
+        extra_config (dict, optional): Extra config items for the LSST task.
         **kwargs: Parsed to run_cmdline_task.
     Returns:
         dict or None: The result of HuntsmanProcessCcdTask.
@@ -162,6 +162,12 @@ def make_calexps(dataIds, rerun, butler_dir, calib_dir, procs=1, clobber_config=
     for dataId in dataIds:
         cmd += " --id"
         for k, v in dataId.items():
+            cmd += f" {k}={v}"
+
+    extra_config = {} if extra_config is None else extra_config
+    if extra_config:
+        cmd += " --config"
+        for k, v in extra_config.items():
             cmd += f" {k}={v}"
 
     result = run_cmdline_task(HuntsmanProcessCcdTask, cmd.split(), doReturnResults=doReturnResults,

--- a/src/huntsman/drp/reduction/lsst.py
+++ b/src/huntsman/drp/reduction/lsst.py
@@ -8,11 +8,18 @@ class LsstDataReduction(DataReductionBase):
 
     """ Data reduction using LSST stack. """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, calexp_kwargs=None, coadd_kwargs=None, *args, **kwargs):
         super().__init__(initialise=False, *args, **kwargs)
 
         self._butler_directory = os.path.join(self.directory, "lsst")
         self._butler_repo = None
+
+        # Setup task configs
+
+        self._calexp_kwargs = {} if calexp_kwargs is None else calexp_kwargs
+        self._calexp_kwargs["procs"] = self.nproc
+
+        self._coadd_kwargs = {} if coadd_kwargs is None else coadd_kwargs
 
         self._initialise()
 
@@ -32,13 +39,12 @@ class LsstDataReduction(DataReductionBase):
         # Ingest reference catalogue
         self._butler_repo.ingest_reference_catalogue([self._refcat_filename])
 
-    def reduce(self, nproc=None):
+    def reduce(self):
         """ Use the LSST stack to calibrate and stack exposures. """
-        nproc = nproc if nproc else self.nproc
 
-        self._butler_repo.make_calexps(procs=nproc)
+        self._butler_repo.make_calexps(**self._calexp_kwargs)
 
-        self._butler_repo.make_coadd()
+        self._butler_repo.make_coadd(**self._coadd_kwargs)
 
     # Private methods
 


### PR DESCRIPTION
Allows users to specify LSST config items for `HuntsmanProcessCcdTask` using the reduction config file.

This is subject to some limitations as it uses the underlying command line task argument parsing from LSST ([documentation](https://pipelines.lsst.io/v/b3545/modules/lsst.pipe.base/command-line-task-config-howto.html#command-line-task-config-howto-configfile)). Most notably we cannot retarget subtasks from the config file.