### PR TITLE
Fix calib maker ingest duplication

### DIFF
--- a/src/huntsman/drp/collection.py
+++ b/src/huntsman/drp/collection.py
@@ -372,7 +372,7 @@ class RawExposureCollection(Collection):
             calib_document (CalibDocument): The calib document to match with.
             calib_date (object): An object that can be interpreted as a date.
         Returns:
-            list of RawExposureDocument: The matching raw calibs.
+            list of RawExposureDocument: The matching raw calibs ordered by increasing time diff.
         """
         # Make the document filter
         dataset_type = calib_document["datasetType"]
@@ -393,6 +393,11 @@ class RawExposureCollection(Collection):
         documents = self.find(doc_filter, date_start=date_start, date_end=date_end)
         self.logger.debug(f"Found {len(documents)} matching raw calib documents for"
                           f" {calib_document} at {calib_date}.")
+
+        # Sort by time difference in increasing order
+        # This makes it easy to select only the nearest matches using indexing
+        timedeltas = [abs(d["date"] - calib_date) for d in documents]
+        documents = [x for _, x in sorted(zip(timedeltas, documents))]
 
         return documents
 

--- a/src/huntsman/drp/collection.py
+++ b/src/huntsman/drp/collection.py
@@ -376,6 +376,7 @@ class RawExposureCollection(Collection):
         # Make the document filter
         dataset_type = calib_document["datasetType"]
         matching_keys = self.config["calibs"]["matching_columns"][dataset_type]
+
         doc_filter = {k: calib_document[k] for k in matching_keys}
 
         # Add dataType to doc filter

--- a/src/huntsman/drp/collection.py
+++ b/src/huntsman/drp/collection.py
@@ -427,9 +427,8 @@ class RawExposureCollection(Collection):
 
         # Get metadata for all raw calibs that are valid for this date
         if documents is None:
-            documents = self._exposure_collection.find(
-                {"dataType": {"in": data_types}},
-                date_start=date_start, date_end=date_end, screen=True, quality_filter=True)
+            documents = self.find({"dataType": {"in": data_types}}, date_start=date_start,
+                                  date_end=date_end, screen=True, quality_filter=True)
         else:
             documents = [d for d in documents if d["dataType"] in data_types]
 

--- a/src/huntsman/drp/collection.py
+++ b/src/huntsman/drp/collection.py
@@ -108,11 +108,12 @@ class Collection(HuntsmanBase):
 
         self.logger.debug(f"Performing mongo find operation with filter: {mongo_filter}.")
 
-        documents = list(self._collection.find(mongo_filter, {"_id": False}))
+        if limit is None:
+            limit = 0
+        cursor = self._collection.find(mongo_filter, {"_id": False}).limit(limit)
+        documents = list(cursor)
 
         self.logger.debug(f"Find operation returned {len(documents)} results.")
-        if limit:
-            documents = documents[:limit]
 
         if key is not None:
             return [d[key] for d in documents]

--- a/src/huntsman/drp/document.py
+++ b/src/huntsman/drp/document.py
@@ -1,4 +1,5 @@
 """ Classes to represent dataIds. """
+from copy import deepcopy
 from collections import abc
 from contextlib import suppress
 
@@ -89,16 +90,30 @@ class Document(abc.Mapping):
         self._document.update(d)
 
     def to_mongo(self, flatten=False):
-        """ Get the full mongo filter for the document """
+        """ Get the full mongo filter for the document.
+        Args:
+            flatten (bool, optional): If True, return flattened dictionary using dot notation.
+                Default False.
+        """
         d = encode_mongo_filter(self._document)
         if not flatten:
             return unflatten_dict(d)
         return d
 
     def get_mongo_id(self):
-        """ Get the unique mongo ID for the document """
+        """ Get the unique mongo ID for the document.
+        Returns:
+            dict: The encoded document.
+        """
         doc = {k: self[k] for k in self._required_keys}
         return encode_mongo_filter(doc)
+
+    def copy(self):
+        """ Copy the document.
+        Returns:
+            Document: The copied document.
+        """
+        return deepcopy(self)
 
     # Private methods
 

--- a/src/huntsman/drp/lsst/butler.py
+++ b/src/huntsman/drp/lsst/butler.py
@@ -291,7 +291,7 @@ class ButlerRepository(HuntsmanBase):
         """
         filenames = set([os.path.abspath(os.path.realpath(_)) for _ in filenames])
 
-        if len(filenames) == 0:
+        if not filenames:
             self.logger.warning(f"No master {datasetType} files to ingest.")
             return
 

--- a/src/huntsman/drp/lsst/butler.py
+++ b/src/huntsman/drp/lsst/butler.py
@@ -303,6 +303,8 @@ class ButlerRepository(HuntsmanBase):
         # Ingest the calib
         self.ingest_master_calibs(datasetType, [filename], validity=validity)
 
+        return filename
+
     def make_master_calibs(self, calib_docs, **kwargs):
         """ Make master calibs for a list of calib documents.
         Args:
@@ -316,8 +318,12 @@ class ButlerRepository(HuntsmanBase):
 
             for calib_doc in [c for c in calib_docs if c["datasetType"] == datasetType]:
                 try:
-                    self.make_master_calib(calib_doc, **kwargs)
-                    docs.append(calib_doc)
+                    filename = self.make_master_calib(calib_doc, **kwargs)
+
+                    # Update the filename
+                    doc = calib_doc.copy()
+                    doc["filename"] = filename
+                    docs.append(doc)
 
                 except Exception as err:
                     self.logger.error(f"Problem making calib for calibId={calib_doc}: {err!r}")

--- a/src/huntsman/drp/lsst/butler.py
+++ b/src/huntsman/drp/lsst/butler.py
@@ -6,7 +6,6 @@ NOTES:
 import os
 from contextlib import suppress
 from tempfile import TemporaryDirectory
-import sqlite3
 
 import lsst.daf.persistence as dafPersist
 from lsst.daf.persistence.policy import Policy
@@ -164,35 +163,6 @@ class ButlerRepository(HuntsmanBase):
             return [{keys[0]: _} for _ in md]
 
         return [{k: v for k, v in zip(keys, _)} for _ in md]
-
-    def get_calib_metadata(self, datasetType, keys_ignore=None):
-        """ Query the ingested calibs. TODO: Replace with the "official" Butler version.
-        Args:
-            datasetType (str): The dataset type (e.g. bias, dark, flat).
-            keys_ignore (list of str, optional): If provided, drop these keys from result.
-        Returns:
-            list of dict: The query result in column: value.
-        """
-        # Access the sqlite DB
-        conn = sqlite3.connect(os.path.join(self.calib_dir, "calibRegistry.sqlite3"))
-        c = conn.cursor()
-
-        # Query the calibs
-        result = c.execute(f"SELECT * from {datasetType}")
-        metadata_list = []
-
-        for row in result:
-            d = {}
-            for idx, col in enumerate(c.description):
-                d[col[0]] = row[idx]
-            metadata_list.append(d)
-        c.close()
-
-        if keys_ignore is not None:
-            keys_keep = [k for k in metadata_list[0].keys() if k not in keys_ignore]
-            metadata_list = [{k: _[k] for k in keys_keep} for _ in metadata_list]
-
-        return metadata_list
 
     def get_dataIds(self, datasetType, dataId=None, extra_keys=None, **kwargs):
         """ Get ingested dataIds for a given datasetType.

--- a/src/huntsman/drp/lsst/butler.py
+++ b/src/huntsman/drp/lsst/butler.py
@@ -147,13 +147,17 @@ class ButlerRepository(HuntsmanBase):
         """
         return self.get(datasetType + "_filename", dataId=dataId, **kwargs)[0]
 
-    def get_metadata(self, datasetType, keys, dataId=None, **kwargs):
+    def get_metadata(self, datasetType, keys=None, dataId=None, **kwargs):
         """ Get metadata for a dataset.
         Args:
             datasetType (str): The dataset type (e.g. raw, flat, calexp).
-            keys (list of str): The keys contained in the metadata.
+            keys (list of str, optional): The keys contained in the metadata. If not provided,
+                will use default keys for datasetType.
             dataId (optional): A list of dataIds to query on.
         """
+        if keys is None:
+            keys = self.get_keys(datasetType, **kwargs)
+
         butler = self.get_butler(**kwargs)
         md = butler.queryMetadata(datasetType, format=keys, dataId=dataId)
 

--- a/src/huntsman/drp/lsst/utils/butler.py
+++ b/src/huntsman/drp/lsst/utils/butler.py
@@ -45,7 +45,7 @@ def get_files_of_type(datasetType, directory, policy):
     return dataIds, filenames
 
 
-def get_all_calibIds(datasetType, dataIds, calibDate, butler):
+def dataIds_to_calibIds(datasetType, dataIds, calibDate, butler):
     """ Get calibIds given a set of dataIds and datasetType.
     Args:
         datasetType (str): The calib type, e.g. flat, bias.

--- a/src/huntsman/drp/lsst/utils/butler.py
+++ b/src/huntsman/drp/lsst/utils/butler.py
@@ -1,19 +1,32 @@
+from lsst.daf.persistence.policy import Policy
 
-def get_filename_template(datasetType, policy):
+
+def load_policy():
+    """ Load the LSST policy.
+    Returns:
+        lsst.daf.persistence.policy.Policy: The policy object.
+    """
+    policy_filename = Policy.defaultPolicyFile("obs_huntsman", "HuntsmanMapper.yaml",
+                                               relativePath="policy")
+    return Policy(policy_filename)
+
+
+def get_filename_template(datasetType):
     """ Get the filename template for a specific datatype.
     Args:
         datasetType (str):
             The dataset type as specified in the policy file. e.g. `exposures.raw`
             or `calibrations.flat`.
-        policy (`lsst.daf.persistence.Policy`):
-            The Policy object.
     Returns:
         str: The filename template.
     """
+    policy = load_policy()
     policy_key = datasetType + ".template"
+
     template = policy[policy_key]
     if template is None:
         raise KeyError(f"Template not found for {datasetType}.")
+
     return template
 
 

--- a/src/huntsman/drp/lsst/utils/butler.py
+++ b/src/huntsman/drp/lsst/utils/butler.py
@@ -1,7 +1,3 @@
-import os
-
-from lsst.daf.persistence import FsScanner
-
 
 def get_filename_template(datasetType, policy):
     """ Get the filename template for a specific datatype.
@@ -19,30 +15,6 @@ def get_filename_template(datasetType, policy):
     if template is None:
         raise KeyError(f"Template not found for {datasetType}.")
     return template
-
-
-def get_files_of_type(datasetType, directory, policy):
-    """ Get the filenames of a specific dataset type under a particular directory that match
-    the appropriate filename template.
-    Args:
-        datasetType (str): The dataset type as specified in the policy file. e.g. `exposures.raw`
-            or `calibrations.flat`.
-        directory (str): The directory to search under (e.g. a butler directory).
-        policy (`lsst.daf.persistence.Policy`): The Policy object.
-    Returns:
-        list of dict: The matching data IDs.
-        list of str: The matching filenames.
-    """
-    # Get the filename tempalte for this file type
-    template = get_filename_template(datasetType, policy)
-
-    # Find filenames that match the template in the directory
-    scanner = FsScanner(template)
-    matches = scanner.processPath(directory)
-    dataIds = list(matches.values())
-    filenames = [os.path.join(directory, f) for f in matches.keys()]
-
-    return dataIds, filenames
 
 
 def dataIds_to_calibIds(datasetType, dataIds, calibDate, butler):

--- a/src/huntsman/drp/lsst/utils/butler.py
+++ b/src/huntsman/drp/lsst/utils/butler.py
@@ -30,34 +30,6 @@ def get_filename_template(datasetType):
     return template
 
 
-def dataIds_to_calibIds(datasetType, dataIds, calibDate, butler):
-    """ Get calibIds given a set of dataIds and datasetType.
-    Args:
-        datasetType (str): The calib type, e.g. flat, bias.
-        dataIds (list of dict): The data ids.
-        butler (lsst.daf.persistence.butler.Butler): The butler object.
-    Returns:
-        list of dict: The set of unique calibIds associated with the dataIds.
-    """
-    # Get required keys
-    calib_keys = [k for k in butler.getKeys(datasetType).keys() if k != "calibDate"]
-
-    # Get key values for each dataId
-    calib_key_values = []
-    for dataId in dataIds:
-        calib_key_values.append(tuple([dataId[k] for k in calib_keys]))
-
-    # Get unique sets of calibIds
-    unique_calib_values = set(calib_key_values)
-    calibIds = [{k: v for k, v in zip(calib_keys, vs)} for vs in unique_calib_values]
-
-    # Add calibDate to calibIds
-    for calibId in calibIds:
-        calibId["calibDate"] = calibDate
-
-    return calibIds
-
-
 def calibId_to_dataIds(datasetType, calibId, butler):
     """ Get ingested dataIds that match a calibId of a given datasetType.
     Args:

--- a/src/huntsman/drp/lsst/utils/calib.py
+++ b/src/huntsman/drp/lsst/utils/calib.py
@@ -1,32 +1,28 @@
 import os
-from lsst.obs.huntsman import HuntsmanMapper
 
 from huntsman.drp.core import get_config
 
 
-def get_calib_filename(datasetType, dataId, config=None, mapper=None):
-    """ Return the archived filename for a calib dataId.
+def get_calib_filename(document, config=None, directory=None):
+    """ Return the archived calib filename for a calib dataId.
     Args:
-        datasetType (str): The datasetType (e.g. bias).
-        dataId (dict): The dataId of the calib.
+        document (abc.Mapping): The mapping with necessary metadata to construct the filename.
+        directory (str, optional): The root directory of the calib. If None, use archive dir from
+            config.
         config (dict, optional): The config. If None (default), will get default config.
-        mapper (lsst.daf.persistence.mapper.Mapper): The mapper object. If None (default), use the
-            default for the obs package. Providing the mapper can speed up runtime since it takes
-            a while to create the mapper object.
     Returns:
         str: The archived calib filename.
     """
-    if not config:
-        config = get_config()
-    archive_dir = config["directories"]["archive"]
+    # Import here to avoid ImportError with screener
+    from huntsman.drp.lsst.utils.butler import get_filename_template
 
-    # The policy yaml file defines the file naming convention
-    # The mapper reads the policy file and turns dataIds into ButlerLocation objects
-    if mapper is None:
-        mapper = HuntsmanMapper()
+    if directory is None:
+        if not config:
+            config = get_config()
+        directory = config["directories"]["archive"]
 
-    filename_list = getattr(mapper, f"map_{datasetType}_filename")(dataId=dataId).locationList
-    if len(filename_list) > 1:
-        raise RuntimeError("dataId matches with multiple locations.")
+    # Load the filename template and get the filename
+    key = f"calibrations.{document['datasetType']}"
+    filename = get_filename_template(key) % document
 
-    return os.path.join(archive_dir, filename_list[0])
+    return os.path.join(directory, filename)

--- a/src/huntsman/drp/services/calexp.py
+++ b/src/huntsman/drp/services/calexp.py
@@ -27,7 +27,6 @@ def _process_document(document, exposure_collection, calib_collection, timeout, 
     directory_prefix = document["expId"]
 
     with TemporaryButlerRepository(logger=logger, config=config,
-                                   calib_collection=calib_collection,
                                    directory_prefix=directory_prefix) as br:
 
         logger.debug(f"Butler directory for {document}: {br.butler_dir}")

--- a/src/huntsman/drp/services/calib.py
+++ b/src/huntsman/drp/services/calib.py
@@ -248,7 +248,7 @@ class MasterCalibMaker(HuntsmanBase):
             pass
 
         # If dataset type is dark, need to add all dependent flats
-        elif dataset_type in ("bias", "dark"):
+        if dataset_type in ("bias", "dark"):
             query = matching_dict.copy()
             query["datasetType"] = "flat"
             new_docs = self._calib_collection.find(query)
@@ -256,7 +256,7 @@ class MasterCalibMaker(HuntsmanBase):
                 calib_docs.update(new_docs)
 
         # If dataset type is dark, need to add all dependent biases and darks
-        elif dataset_type == "bias":
+        if dataset_type == "bias":
             query = matching_dict.copy()
             query["datasetType"] = {"in": ["dark", "flat"]}
             new_docs = self._calib_collection.find(query)

--- a/src/huntsman/drp/services/calib.py
+++ b/src/huntsman/drp/services/calib.py
@@ -194,6 +194,9 @@ class MasterCalibMaker(HuntsmanBase):
         """ Identify which calib IDs need processing and which should be ingested.
         Args:
             calib_docs (list of CalibDocument): The list of calib docs to check.
+        Returns:
+            Set of CalibDocument: Calib documents that need to be processed.
+            Set of CalibDocument: Calib documents that need to be ingested.
         """
         calibs_to_process = set()
         calibs_to_ingest = set()

--- a/src/huntsman/drp/tests/test_butler.py
+++ b/src/huntsman/drp/tests/test_butler.py
@@ -132,7 +132,7 @@ def test_make_master_calibs(exposure_collection, config):
         br.make_master_calibs(calib_docs, rerun=rerun)
 
         # Check the biases in the butler dir
-        metadata_bias = br.get_metadata(datasetType="bias", rerun=rerun)
+        metadata_bias = br.get_dataIds(datasetType="bias", rerun=rerun)
         assert len(metadata_bias) == n_bias
         ccds = set()
         for md in metadata_bias:
@@ -140,7 +140,7 @@ def test_make_master_calibs(exposure_collection, config):
         assert len(ccds) == n_cameras
 
         # Check the darks in the butler dir
-        metadata_dark = br.get_calib_metadata(datasetType="dark")
+        metadata_dark = br.get_dataIds(datasetType="dark", rerun=rerun)
         assert len(metadata_dark) == n_dark
         ccds = set()
         for md in metadata_dark:
@@ -148,7 +148,7 @@ def test_make_master_calibs(exposure_collection, config):
         assert len(ccds) == n_cameras
 
         # Check the flats in the butler dir
-        metadata_flat = br.get_calib_metadata(datasetType="flat")
+        metadata_flat = br.get_dataIds(datasetType="flat", rerun=rerun)
         assert len(metadata_flat) == n_flat
         filters = set()
         ccds = set()

--- a/src/huntsman/drp/tests/test_butler.py
+++ b/src/huntsman/drp/tests/test_butler.py
@@ -96,6 +96,7 @@ def test_make_master_calibs(exposure_collection, config):
     doc = exposure_collection.find()[0]
     doc_filter = {k: doc[k] for k in ["CAM-ID", "dateObs"]}
     docs = exposure_collection.find(doc_filter)
+    calib_docs = exposure_collection.get_calib_docs(current_date(), documents=docs)
 
     n_cameras = 1
     n_days = 1
@@ -121,18 +122,19 @@ def test_make_master_calibs(exposure_collection, config):
 
     filenames = [d["filename"] for d in docs]
 
+    rerun = "test_rerun"
     with TemporaryButlerRepository(config=config) as br:
 
         br.ingest_raw_data(filenames)
 
         # Make the calibs
-        br.make_master_calibs(calib_date=current_date(), rerun="test_rerun")
+        br.make_master_calibs(calib_docs, rerun=rerun)
 
         # Archive the calibs
         br.archive_master_calibs()
 
         # Check the biases in the butler dir
-        metadata_bias = br.get_calib_metadata(datasetType="bias")
+        metadata_bias = br.get_metadata(datasetType="bias", rerun=rerun)
         assert len(metadata_bias) == n_bias
         ccds = set()
         for md in metadata_bias:

--- a/src/huntsman/drp/tests/test_butler.py
+++ b/src/huntsman/drp/tests/test_butler.py
@@ -2,7 +2,6 @@ import os
 from collections import defaultdict
 
 from huntsman.drp.utils.date import current_date
-from huntsman.drp.collection import MasterCalibCollection
 from huntsman.drp.lsst.butler import ButlerRepository, TemporaryButlerRepository
 
 
@@ -132,7 +131,7 @@ def test_make_master_calibs(exposure_collection, config):
         br.make_master_calibs(calib_docs, rerun=rerun)
 
         # Check the biases in the butler dir
-        metadata_bias = br.get_dataIds(datasetType="bias", rerun=rerun)
+        metadata_bias = br.get_dataIds(datasetType="bias")
         assert len(metadata_bias) == n_bias
         ccds = set()
         for md in metadata_bias:

--- a/src/huntsman/drp/tests/test_butler.py
+++ b/src/huntsman/drp/tests/test_butler.py
@@ -96,6 +96,7 @@ def test_make_master_calibs(exposure_collection, config):
     doc = exposure_collection.find()[0]
     doc_filter = {k: doc[k] for k in ["CAM-ID", "dateObs"]}
     docs = exposure_collection.find(doc_filter)
+
     calib_docs = exposure_collection.get_calib_docs(current_date(), documents=docs)
 
     n_cameras = 1

--- a/src/huntsman/drp/tests/test_butler.py
+++ b/src/huntsman/drp/tests/test_butler.py
@@ -131,9 +131,6 @@ def test_make_master_calibs(exposure_collection, config):
         # Make the calibs
         br.make_master_calibs(calib_docs, rerun=rerun)
 
-        # Archive the calibs
-        br.archive_master_calibs()
-
         # Check the biases in the butler dir
         metadata_bias = br.get_metadata(datasetType="bias", rerun=rerun)
         assert len(metadata_bias) == n_bias
@@ -160,18 +157,6 @@ def test_make_master_calibs(exposure_collection, config):
             ccds.update([md["ccd"]])
         assert len(filters) == n_filters
         assert len(ccds) == n_cameras
-
-        # Check the calibs in the archive
-        master_calib_collection = MasterCalibCollection(config=config)
-        calib_metadata = master_calib_collection.find()
-        filenames = [c["filename"] for c in calib_metadata]
-        datasettypes = [c["datasetType"] for c in calib_metadata]
-        assert len(calib_metadata) == n_flat + n_bias + n_dark
-        assert sum([c == "flat" for c in datasettypes]) == n_flat
-        assert sum([c == "bias" for c in datasettypes]) == n_bias
-        assert sum([c == "dark" for c in datasettypes]) == n_dark
-        for filename in filenames:
-            assert os.path.isfile(filename)
 
 
 def test_make_coadd(exposure_collection_real_data, master_calib_collection_real_data,

--- a/src/huntsman/drp/tests/test_calib.py
+++ b/src/huntsman/drp/tests/test_calib.py
@@ -1,3 +1,4 @@
+import os
 import time
 import pytest
 
@@ -103,6 +104,9 @@ def test_master_calib_maker(calib_maker, config):
             if len([d for d in dataset_types if d == "bias"]) == n_bias:
                 if len([d for d in dataset_types if d == "dark"]) == n_dark:
                     break
+
+        for filename in calib_collection.find(key="filename"):
+            assert os.path.isfile(filename)
 
         if not calib_maker.is_running:
             raise RuntimeError("Calib maker has stopped running. Check the logs for details.")

--- a/src/huntsman/drp/utils/testing.py
+++ b/src/huntsman/drp/utils/testing.py
@@ -1,6 +1,7 @@
 import os
 import yaml
 import time
+from glob import glob
 from datetime import timedelta
 import numpy as np
 from astropy.io import fits
@@ -12,6 +13,7 @@ from huntsman.drp.base import HuntsmanBase
 from huntsman.drp.utils.date import parse_date
 from huntsman.drp.collection import RawExposureCollection, MasterCalibCollection
 from huntsman.drp.services.ingestor import FileIngestor
+from huntsman.drp.lsst.utils.calib import get_calib_filename
 
 
 EXPTIME_BIAS = 1E-32  # Minimum exposure time for ZWO cameras is > 0
@@ -58,7 +60,7 @@ def get_refcat_filename(config):
     return os.path.join(config["directories"]["root"], "tests", "data", "refcat.csv")
 
 
-def create_test_bulter_repository(directory, config=None, **kwargs):
+def create_test_bulter_repository(directory, config=None, with_calibs=False, **kwargs):
     """ Create a butler repository and ingest the testing dataset.
     Args:
         **kwargs: Parsed to ButlerRepository.
@@ -76,6 +78,14 @@ def create_test_bulter_repository(directory, config=None, **kwargs):
     # Ingest the refcat
     refcat_filename = get_refcat_filename(config)
     br.ingest_reference_catalogue([refcat_filename])
+
+    if with_calibs:
+        rootdir = os.path.join(config["directories"]["root"], "tests", "data", "calib")
+
+        for datasetType in config["calibs"]["types"]:
+            dir = os.path.join(rootdir, datasetType)
+            filenames = [y for x in os.walk(dir) for y in glob(os.path.join(x[0], '*.fits'))]
+            br.ingest_master_calibs(datasetType, filenames)
 
     return br
 
@@ -126,10 +136,34 @@ def create_test_calib_collection(config=None):
     calib_collection.delete_all(really=True)
     assert not calib_collection.find()
 
-    dir = os.path.join(config["directories"]["root"], "tests", "data")
+    rootdir = os.path.join(config["directories"]["root"], "tests", "data", "calib")
 
-    with TemporaryButlerRepository() as br:
-        br.archive_master_calibs(directory=dir)
+    # Use a butler instance to ingest master calibs and get metadata
+    calibIds = []
+    filenames = []
+    with TemporaryButlerRepository(config=config) as br:
+
+        for datasetType in config["calibs"]["types"]:
+
+            dir = os.path.join(rootdir, datasetType)
+            fnames = [y for x in os.walk(dir) for y in glob(os.path.join(x[0], '*.fits'))]
+
+            # Ingest calibs
+            br.ingest_master_calibs(datasetType, fnames)
+
+            # Get the calibIds
+            mds = br.get_dataIds(datasetType)
+            for md in mds:
+                md["datasetType"] = datasetType
+            calibIds.extend(mds)
+
+            # Get the corresponding ordered filenames
+            fnames = [get_calib_filename(_, config=config, directory=br.calib_dir) for _ in mds]
+            filenames.extend(fnames)
+
+        # Archive the files
+        for filename, calibId in zip(filenames, calibIds):
+            calib_collection.archive_master_calib(filename, calibId)
 
     assert calib_collection.find()
     return calib_collection

--- a/src/huntsman/drp/utils/testing.py
+++ b/src/huntsman/drp/utils/testing.py
@@ -128,7 +128,7 @@ def create_test_calib_collection(config=None):
 
     dir = os.path.join(config["directories"]["root"], "tests", "data")
 
-    with TemporaryButlerRepository(calib_collection=calib_collection) as br:
+    with TemporaryButlerRepository() as br:
         br.archive_master_calibs(directory=dir)
 
     assert calib_collection.find()


### PR DESCRIPTION
Refactor the calib maker class. 

New features:
- Make sure most recent calibs are used if there are more than the maximum amount of matches
- `MasterCalibMaker` updates dependent calibs as well as ones with new files

Closes #158 

#41 still seems to be a problem.