### PR TITLE
Trigger calexp metric update

### DIFF
--- a/scripts/calexp/trigger_metric_update.py
+++ b/scripts/calexp/trigger_metric_update.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+"""
+Trigger calexp metrics to be reprocessed.
+"""
+from contextlib import suppress
+
+from huntsman.drp.collection import RawExposureCollection
+from huntsman.drp.services.calexp import CALEXP_METRIC_TRIGGER
+
+UPDATE = {f"metrics.calexp.{CALEXP_METRIC_TRIGGER}": True}
+
+if __name__ == "__main__":
+
+    raw = RawExposureCollection()
+
+    for doc in raw.find(screen=False, quality_filter=False):
+        with suppress(KeyError):
+            raw.update_one(doc, UPDATE)


### PR DESCRIPTION
Add a script to trigger update of all calexp metrics. This script should be run e.g. after updating the calexp metric code.

Closes #159 