### PR TITLE
Make it easier to resume reductions

### DIFF
--- a/src/huntsman/drp/reduction/base.py
+++ b/src/huntsman/drp/reduction/base.py
@@ -39,8 +39,8 @@ class ReductionBase(HuntsmanBase):
             calib_collection = MasterCalibCollection(config=self.config)
         self._calib_collection = calib_collection
 
-        self.science_docs = None
-        self.calib_docs = None
+        self.science_docs = self._exposure_collection.find(**self._query)
+        self.calib_docs = self._get_calibs(self.science_docs)
 
         if initialise:
             self._initialise()
@@ -54,12 +54,6 @@ class ReductionBase(HuntsmanBase):
         This method is responsible for querying the database, ingesting the files and producing
         the reference catalogue.
         """
-        # Identify science docs
-        self.science_docs = self._exposure_collection.find(**self._query)
-
-        # Get matching master calibs
-        self.calib_docs = self._get_calibs(self.science_docs)
-
         # Make reference catalogue
         self._make_reference_catalogue()
 

--- a/src/huntsman/drp/reduction/lsst.py
+++ b/src/huntsman/drp/reduction/lsst.py
@@ -49,7 +49,8 @@ class LsstReduction(ReductionBase):
         dataIds = [self._butler_repo.document_to_dataId(d) for d in self.science_docs]
 
         self.logger.info(f"Making calexps for {len(self.science_docs)} science images.")
-        self._butler_repo.make_calexps(dataIds=dataIds, **self._calexp_kwargs)
+        self._butler_repo.make_calexps(dataIds=dataIds, remake_existing=False,
+                                       **self._calexp_kwargs)
 
         self.logger.info(f"Making coadds from {len(self.science_docs)} calexps.")
         self._butler_repo.make_coadd(dataIds=dataIds, **self._coadd_kwargs)

--- a/src/huntsman/drp/refcat.py
+++ b/src/huntsman/drp/refcat.py
@@ -197,6 +197,8 @@ class RefcatClient(HuntsmanBase):
         Args:
             *args, **kwargs: Parsed to TapReferenceCatalogue.make_reference_catalogue.
         """
+        self.logger.info("Creating reference catalogue.")
+
         filename = kwargs.pop("filename", None)  # file needs to be stored on local volume
 
         # Get and decode the data sent over the network


### PR DESCRIPTION
- Move document find operation to `Reduction` initialisation
- Avoid remaking existing `calexp`s

Closes #177 