### PR TITLE
skymapper tap url change to https or something

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -82,7 +82,7 @@ calibs:
       - detector
 
 refcat:
-  tap_url: http://api.skymapper.nci.org.au/aus/tap/
+  tap_url: https://api.skymapper.nci.org.au/aus/tap/
   tap_table: dr3.master
   ra_key: raj2000
   dec_key: dej2000


### PR DESCRIPTION
old url gives following http error/msg
``` 
In [39]: tap.cone_search(coords[0], rcfn)
2021-08-19 02:56:09.208 | DEBUG    | huntsman.drp.refcat:cone_search:85 - Cone search command: SELECT * FROM dr3.master WHERE 1=CONTAINS(POINT('ICRS', raj2000, dej2000), CIRCLE('ICRS', 319.3151228469846, -8.222831183555451, 1)) AND class_star >= 0.9 AND g_psf < 15 AND flags = 0.
---------------------------------------------------------------------------
HTTPError                                 Traceback (most recent call last)
<ipython-input-39-5a2fcac73f42> in <module>
----> 1 tap.cone_search(coords[0], rcfn)

/opt/lsst/software/stack/huntsman-drp/src/huntsman/drp/refcat.py in cone_search(self, coord, filename, radius_degrees)
     85         self.logger.debug(f"Cone search command: {query}.")
     86 
---> 87         self._tap.launch_job_async(query, dump_to_file=True, output_format="csv",
     88                                    output_file=filename)
     89         return pd.read_csv(filename)

/opt/lsst/software/stack/conda/miniconda3-py38_4.9.2/envs/lsst-scipipe-0.6.0/lib/python3.8/site-packages/astroquery/utils/tap/core.py in launch_job_async(self, query, name, output_file, output_format, verbose, dump_to_file, background, upload_resource, upload_table_name, autorun)
    431                 self.__connHandler.dump_to_file(suitableOutputFile,
    432                                                 response)
--> 433             raise requests.exceptions.HTTPError(response.reason)
    434         else:
    435             location = self.__connHandler.find_header(

HTTPError: Moved Permanently
```