### PR TITLE
Add task overrides from config for QualityMonitor

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -56,6 +56,11 @@ collections:
     index_fields:
       - filename
 
+# Config items for the QualityMonitor service
+QualityMonitor:
+  pipeline_config:  # LSST task overrides
+    "calibrate:doDeblend": false  # Turn off deblending to save compute resources
+
 # Config items for calibs
 calibs:
   types:  # In order of creation

--- a/src/huntsman/drp/collection/exposure.py
+++ b/src/huntsman/drp/collection/exposure.py
@@ -10,6 +10,7 @@ from huntsman.drp.collection.collection import Collection
 from huntsman.drp.collection.calib import ReferenceCalibCollection
 from huntsman.drp.document import ExposureDocument, CalibDocument
 from huntsman.drp.metrics.raw import metric_evaluator
+from huntsman.drp.document import CalibDocument, ExposureDocument
 
 __all__ = ("ExposureCollection",)
 

--- a/src/huntsman/drp/lsst/butler.py
+++ b/src/huntsman/drp/lsst/butler.py
@@ -477,7 +477,7 @@ class ButlerRepository(HuntsmanBase):
         return taskClass(config=config, **kwargs)
 
 
-class TemporaryButlerRepository():
+class TemporaryButlerRepository(HuntsmanBase):
     """ Class to return a ButlerRepository in a temporary directory.
     Used as a context manager.
     """

--- a/src/huntsman/drp/services/quality.py
+++ b/src/huntsman/drp/services/quality.py
@@ -1,11 +1,12 @@
 import tempfile
-from functools import partial
 from multiprocessing.pool import ThreadPool
 
 from huntsman.drp.services.base import ProcessQueue
 from huntsman.drp.lsst.butler import TemporaryButlerRepository
 from huntsman.drp.refcat import RefcatClient
 from huntsman.drp.metrics.calexp import metric_evaluator
+from huntsman.drp.collection import ExposureCollection, CalibCollection
+
 
 __all__ = ("QualityMonitor",)
 
@@ -15,79 +16,13 @@ __all__ = ("QualityMonitor",)
 CALEXP_METRIC_TRIGGER = "CALEXP_METRIC_TRIGGER"
 
 
-def _process_document(document, exposure_collection, calib_collection, timeout, **kwargs):
-    """ Create a calibrated exposure (calexp) for the given data ID and store the metadata.
-    Args:
-        document (ExposureDocument): The document to process.
-    """
-    config = exposure_collection.config
-    logger = calib_collection.logger
-
-    logger.info(f"Processing document: {document}")
-
-    # Get matching calibs for this document
-    # If there is no matching set, this will raise an error
-    calib_docs = calib_collection.get_matching_calibs(document)
-
-    # Use a directory prefix for the temporary directory
-    # This is necessary as the tempfile module is apparently creating duplicates(!)
-    directory_prefix = str(document["detector_exposure_id"])
-
-    with TemporaryButlerRepository(logger=logger, config=config, prefix=directory_prefix) as br:
-
-        # Ingest raw science exposure into the bulter repository
-        logger.debug(f"Ingesting raw data for {document}")
-        br.ingest_raw_files([document["filename"]])
-
-        # Ingest the corresponding master calibs
-        logger.debug(f"Ingesting master calibs for {document}")
-        for calib_type, calib_doc in calib_docs.items():
-            calib_filename = calib_doc["filename"]
-            br.ingest_calibs(datasetType=calib_type, filenames=[calib_filename])
-
-        # Make and ingest the reference catalogue
-        logger.debug(f"Making refcat for {document}")
-        with tempfile.NamedTemporaryFile(prefix=directory_prefix) as tf:
-            with RefcatClient(config=config, logger=logger) as refcat_client:
-
-                refcat_client.make_from_documents([document], filename=tf.name)
-                br.ingest_reference_catalogue([tf.name])
-
-        # Make the calexp
-        logger.debug(f"Making calexp for {document}")
-        dataId = br.document_to_dataId(document)
-        br.construct_calexps(dataIds=[dataId])
-
-        # Retrieve the calexp results
-        logger.debug(f"Reading calexp outputs for {document}")
-        dataId = br.document_to_dataId(document, datasetType="calexp")
-        outputs = {}
-        for output_name in ("calexp", "src", "calexpBackground"):
-            outputs[output_name] = br.get(output_name, dataId=dataId)
-
-        # Evaluate metrics
-        logger.debug(f"Calculating metrics for {document}")
-        metrics, success = metric_evaluator.evaluate(**outputs)
-
-    # Mark processing complete
-    metrics[CALEXP_METRIC_TRIGGER] = False
-
-    # Update the existing document with calexp metrics
-    to_update = {"metrics": {"calexp": metrics}}
-    exposure_collection.update_one(document_filter=document, to_update=to_update)
-
-    # Raise an exception if not success
-    if not success:
-        raise RuntimeError(f"Metric evaluation unsuccessful for {document}.")
-
-
 class QualityMonitor(ProcessQueue):
     """ Class to continually evauate and archive calexp quality metrics for raw exposures that
     have not already been processed. Intended to run as a docker service.
     """
     _pool_class = ThreadPool  # Use ThreadPool as LSST code makes its own subprocesses
 
-    def __init__(self, nproc=None, timeout=None, *args, **kwargs):
+    def __init__(self, nproc=None, timeout=None, pipeline_config=None, *args, **kwargs):
         """
         Args:
             nproc (int): The number of processes to use. If None (default), will check the config
@@ -104,14 +39,84 @@ class QualityMonitor(ProcessQueue):
         self.logger.debug(f"Calexp monitor using {nproc} processes.")
 
         # Specify timeout for calexp processing
+        # TODO: Actually implement this downstream
         self._timeout = timeout if timeout is not None else calexp_config.get("timeout", None)
+
+        # Set pipeline config overrides
+        self.pipeline_config = pipeline_config
+
+        # Create collection client objects
+        self.exposure_collection = ExposureCollection.from_config(self.config)
+        self.calib_collection = CalibCollection.from_config(self.config)
+
+    # Public methods
+
+    def process_document(self, document, **kwargs):
+        """ Create a calibrated exposure (calexp) for the given data ID and store the metadata.
+        Args:
+            document (ExposureDocument): The document to process.
+        """
+        self.logger.info(f"Processing document: {document}")
+
+        # Get matching calibs for this document
+        # If there is no matching set, this will raise an error
+        calib_docs = self.calib_collection.get_matching_calibs(document)
+
+        # Use a directory prefix for the temporary directory
+        # This is necessary as the tempfile module is apparently creating duplicates(!)
+        directory_prefix = str(document["detector_exposure_id"])
+
+        with TemporaryButlerRepository.from_config(self.config, prefix=directory_prefix) as br:
+
+            # Ingest raw science exposure into the bulter repository
+            self.logger.debug(f"Ingesting raw data for {document}")
+            br.ingest_raw_files([document["filename"]])
+
+            # Ingest the corresponding master calibs
+            self.logger.debug(f"Ingesting master calibs for {document}")
+            for calib_type, calib_doc in calib_docs.items():
+                calib_filename = calib_doc["filename"]
+                br.ingest_calibs(datasetType=calib_type, filenames=[calib_filename])
+
+            # Make and ingest the reference catalogue
+            self.logger.debug(f"Making refcat for {document}")
+            with tempfile.NamedTemporaryFile(prefix=directory_prefix) as tf:
+                with RefcatClient.from_config(self.config) as refcat_client:
+                    refcat_client.make_from_documents([document], filename=tf.name)
+                    br.ingest_reference_catalogue([tf.name])
+
+            # Make the calexp
+            self.logger.debug(f"Making calexp for {document}")
+            dataId = br.document_to_dataId(document)
+            br.construct_calexps(dataIds=[dataId], config=self.pipeline_config)
+
+            # Retrieve the calexp results
+            self.logger.debug(f"Reading calexp outputs for {document}")
+            dataId = br.document_to_dataId(document, datasetType="calexp")
+            outputs = {}
+            for output_name in ("calexp", "src", "calexpBackground"):
+                outputs[output_name] = br.get(output_name, dataId=dataId)
+
+            # Evaluate metrics
+            self.logger.debug(f"Calculating metrics for {document}")
+            metrics, success = metric_evaluator.evaluate(**outputs)
+
+        # Mark processing complete
+        metrics[CALEXP_METRIC_TRIGGER] = False
+
+        # Update the existing document with calexp metrics
+        to_update = {"metrics": {"calexp": metrics}}
+        self.exposure_collection.update_one(document_filter=document, to_update=to_update)
+
+        # Raise an exception if not success
+        if not success:
+            raise RuntimeError(f"Metric evaluation unsuccessful for {document}.")
+
+    # Private methods
 
     def _async_process_objects(self, *args, **kwargs):
         """ Continually process objects in the queue. """
-
-        func = partial(_process_document, timeout=self._timeout)
-
-        return super()._async_process_objects(process_func=func)
+        return super()._async_process_objects(process_func=self.process_document)
 
     def _get_objs(self):
         """ Update the set of data IDs that require processing. """


### PR DESCRIPTION
- Add ability to specify pipeline overrides for `QualityMonitor`
- Deactivate source deblending by default for `QualityMonitor` to save compute resources
- Move `_process_document` to `QualityMonitor.process_document` as we are using a ThreadPool not Pool
- Use `HuntsmanBase` as base class for `TemporaryButlerRepository` to get `from_config` functionality
